### PR TITLE
fix: update link to correct Plugins section in installation guide

### DIFF
--- a/web/src/pages/start/installation.md
+++ b/web/src/pages/start/installation.md
@@ -65,7 +65,7 @@ You should see a significant upgrade from standard HTML styles
 
 ![installation-html.png](../../assets/installation-html.png)
 
-If you want to add a pre-built color theme, check out the [Plugins](/plugins/intro) section
+If you want to add a pre-built color theme, check out the [Plugins](/start/plugins) section
 
 ## ESM Imports
 


### PR DESCRIPTION
Fixed broken link in Installation section that was pointing to `/plugins/intro` by updating it to point to  `/start/plugins` .