### PR TITLE
ironclad/dynamic themes

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webtui/css",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/css/src/base.css
+++ b/packages/css/src/base.css
@@ -16,17 +16,15 @@
     --font-family: monospace;
   }
 
-  @media(prefers-color-scheme: dark) {
-    :root {
-      --background0: #000;
-      --background1: #222;
-      --background2: #444;
-      --background3: #666;
+  [data-webtui-theme="dark"] {
+    --background0: #000;
+    --background1: #222;
+    --background2: #444;
+    --background3: #666;
 
-      --foreground0: #fff;
-      --foreground1: #ccc;
-      --foreground2: #999;
-    }
+    --foreground0: #fff;
+    --foreground1: #ccc;
+    --foreground2: #999;
   }
 
   body,

--- a/packages/theme-catppuccin/package.json
+++ b/packages/theme-catppuccin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webtui/theme-catppuccin",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/theme-catppuccin/src/base.css
+++ b/packages/theme-catppuccin/src/base.css
@@ -1,6 +1,7 @@
-@layer utils {
-  :root {
-    /* Catppuccin Pallette Colors */
+@layer base {
+
+  [data-webtui-theme="catppuccin"],
+  [data-webtui-theme="catppuccin-mocha"] {
     --rosewater: #f5e0dc;
     --flamingo: #f2cdcd;
     --pink: #f5c2e7;
@@ -27,7 +28,96 @@
     --base: #1e1e2e;
     --mantle: #181825;
     --crust: #11111b;
+  }
 
+  [data-webtui-theme="catppuccin-macchiato"] {
+    --rosewater: #f4dbd6;
+    --flamingo: #f0c6c6;
+    --pink: #f5bde6;
+    --mauve: #c6a0f6;
+    --red: #ed8796;
+    --maroon: #ee99a0;
+    --peach: #f5a97f;
+    --yellow: #eed49f;
+    --green: #a6da95;
+    --teal: #8bd5ca;
+    --sky: #91d7e3;
+    --sapphire: #7dc4e4;
+    --blue: #8aadf4;
+    --lavender: #b7bdf8;
+    --text: #cad3f5;
+    --subtext1: #b8c0e0;
+    --subtext0: #a5adcb;
+    --overlay2: #939ab7;
+    --overlay1: #8087a2;
+    --overlay0: #6e738d;
+    --surface2: #5b6078;
+    --surface1: #494d64;
+    --surface0: #363a4f;
+    --base: #24273a;
+    --mantle: #1e2030;
+    --crust: #181926;
+  }
+
+  [data-webtui-theme="catppuccin-frappe"] {
+    --rosewater: #f2d5cf;
+    --flamingo: #eebebe;
+    --pink: #f4b8e4;
+    --mauve: #ca9ee6;
+    --red: #e78284;
+    --maroon: #ea999c;
+    --peach: #ef9f76;
+    --yellow: #e5c890;
+    --green: #a6d189;
+    --teal: #81c8be;
+    --sky: #99d1db;
+    --sapphire: #85c1dc;
+    --blue: #8caaee;
+    --lavender: #babbf1;
+    --text: #c6d0f5;
+    --subtext1: #b5bfe2;
+    --subtext0: #a5adce;
+    --overlay2: #949cbb;
+    --overlay1: #838ba7;
+    --overlay0: #737994;
+    --surface2: #626880;
+    --surface1: #51576d;
+    --surface0: #414559;
+    --base: #303446;
+    --mantle: #292c3c;
+    --crust: #232634;
+  }
+
+  [data-webtui-theme="catppuccin-latte"] {
+    --rosewater: #dc8a78;
+    --flamingo: #dd7878;
+    --pink: #ea76cb;
+    --mauve: #8839ef;
+    --red: #d20f39;
+    --maroon: #e64553;
+    --peach: #fe640b;
+    --yellow: #df8e1d;
+    --green: #40a02b;
+    --teal: #179299;
+    --sky: #04a5e5;
+    --sapphire: #209fb5;
+    --blue: #1e66f5;
+    --lavender: #7287fd;
+    --text: #4c4f69;
+    --subtext1: #5c5f77;
+    --subtext0: #6c6f85;
+    --overlay2: #7c7f93;
+    --overlay1: #8c8fa1;
+    --overlay0: #9ca0b0;
+    --surface2: #acb0be;
+    --surface1: #bcc0cc;
+    --surface0: #ccd0da;
+    --base: #eff1f5;
+    --mantle: #e6e9ef;
+    --crust: #dce0e8;
+  }
+
+  [data-webtui-theme|="catppuccin"] {
     --background0: var(--base);
     --background1: var(--surface0);
     --background2: var(--surface1);

--- a/packages/theme-catppuccin/src/components/badge.css
+++ b/packages/theme-catppuccin/src/components/badge.css
@@ -1,73 +1,75 @@
 @layer components {
-  [is-~="badge"] {
-    &[variant-="rosewater"] {
-      --badge-color: var(--rosewater);
-      --badge-text: var(--background0);
-    }
+  [data-webtui-theme|="catppuccin"] {
+    [is-~="badge"] {
+      &[variant-="rosewater"] {
+        --badge-color: var(--rosewater);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="flamingo"] {
-      --badge-color: var(--flamingo);
-      --badge-text: var(--background0);
-    }
+      &[variant-="flamingo"] {
+        --badge-color: var(--flamingo);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="pink"] {
-      --badge-color: var(--pink);
-      --badge-text: var(--background0);
-    }
+      &[variant-="pink"] {
+        --badge-color: var(--pink);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="mauve"] {
-      --badge-color: var(--mauve);
-      --badge-text: var(--background0);
-    }
+      &[variant-="mauve"] {
+        --badge-color: var(--mauve);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="red"] {
-      --badge-color: var(--red);
-      --badge-text: var(--background0);
-    }
+      &[variant-="red"] {
+        --badge-color: var(--red);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="maroon"] {
-      --badge-color: var(--maroon);
-      --badge-text: var(--background0);
-    }
+      &[variant-="maroon"] {
+        --badge-color: var(--maroon);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="peach"] {
-      --badge-color: var(--peach);
-      --badge-text: var(--background0);
-    }
+      &[variant-="peach"] {
+        --badge-color: var(--peach);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="yellow"] {
-      --badge-color: var(--yellow);
-      --badge-text: var(--background0);
-    }
+      &[variant-="yellow"] {
+        --badge-color: var(--yellow);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="green"] {
-      --badge-color: var(--green);
-      --badge-text: var(--background0);
-    }
+      &[variant-="green"] {
+        --badge-color: var(--green);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="teal"] {
-      --badge-color: var(--teal);
-      --badge-text: var(--background0);
-    }
+      &[variant-="teal"] {
+        --badge-color: var(--teal);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="sky"] {
-      --badge-color: var(--sky);
-      --badge-text: var(--background0);
-    }
+      &[variant-="sky"] {
+        --badge-color: var(--sky);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="sapphire"] {
-      --badge-color: var(--sapphire);
-      --badge-text: var(--background0);
-    }
+      &[variant-="sapphire"] {
+        --badge-color: var(--sapphire);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="blue"] {
-      --badge-color: var(--blue);
-      --badge-text: var(--background0);
-    }
+      &[variant-="blue"] {
+        --badge-color: var(--blue);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="lavender"] {
-      --badge-color: var(--lavender);
-      --badge-text: var(--background0);
+      &[variant-="lavender"] {
+        --badge-color: var(--lavender);
+        --badge-text: var(--background0);
+      }
     }
   }
 }

--- a/packages/theme-catppuccin/src/components/button.css
+++ b/packages/theme-catppuccin/src/components/button.css
@@ -1,73 +1,75 @@
 @layer components {
-  button {
-    &[variant-="rosewater"] {
-      --button-primary: var(--rosewater);
-      --button-secondary: var(--background0);
-    }
+  [data-webtui-theme|="catppuccin"] {
+    button {
+      &[variant-="rosewater"] {
+        --button-primary: var(--rosewater);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="flamingo"] {
-      --button-primary: var(--flamingo);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="flamingo"] {
+        --button-primary: var(--flamingo);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="pink"] {
-      --button-primary: var(--pink);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="pink"] {
+        --button-primary: var(--pink);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="mauve"] {
-      --button-primary: var(--mauve);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="mauve"] {
+        --button-primary: var(--mauve);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="red"] {
-      --button-primary: var(--red);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="red"] {
+        --button-primary: var(--red);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="maroon"] {
-      --button-primary: var(--maroon);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="maroon"] {
+        --button-primary: var(--maroon);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="peach"] {
-      --button-primary: var(--peach);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="peach"] {
+        --button-primary: var(--peach);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="yellow"] {
-      --button-primary: var(--yellow);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="yellow"] {
+        --button-primary: var(--yellow);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="green"] {
-      --button-primary: var(--green);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="green"] {
+        --button-primary: var(--green);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="teal"] {
-      --button-primary: var(--teal);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="teal"] {
+        --button-primary: var(--teal);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="sky"] {
-      --button-primary: var(--sky);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="sky"] {
+        --button-primary: var(--sky);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="sapphire"] {
-      --button-primary: var(--sapphire);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="sapphire"] {
+        --button-primary: var(--sapphire);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="blue"] {
-      --button-primary: var(--blue);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="blue"] {
+        --button-primary: var(--blue);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="lavender"] {
-      --button-primary: var(--lavender);
-      --button-secondary: var(--background0);
+      &[variant-="lavender"] {
+        --button-primary: var(--lavender);
+        --button-secondary: var(--background0);
+      }
     }
   }
 }

--- a/packages/theme-catppuccin/src/components/typography.css
+++ b/packages/theme-catppuccin/src/components/typography.css
@@ -1,43 +1,45 @@
 @layer components {
-  h1 {
-    color: var(--red);
-  }
-
-  h2 {
-    color: var(--peach);
-  }
-
-  h3 {
-    color: var(--yellow);
-  }
-
-  h4 {
-    color: var(--green);
-  }
-
-  h5 {
-    color: var(--blue);
-  }
-
-  h6 {
-    color: var(--purple);
-  }
-
-  p,
-  blockquote,
-  li,
-  [is-~="typography-block"] {
-    a {
-      color: var(--sky);
-      text-decoration: underline;
-
-      &:hover {
-        color: var(--blue);
-      }
+  [data-webtui-theme|="catppuccin"] {
+    h1 {
+      color: var(--red);
     }
 
-    code {
-      color: var(--red);
+    h2 {
+      color: var(--peach);
+    }
+
+    h3 {
+      color: var(--yellow);
+    }
+
+    h4 {
+      color: var(--green);
+    }
+
+    h5 {
+      color: var(--blue);
+    }
+
+    h6 {
+      color: var(--purple);
+    }
+
+    p,
+    blockquote,
+    li,
+    [is-~="typography-block"] {
+      a {
+        color: var(--sky);
+        text-decoration: underline;
+
+        &:hover {
+          color: var(--blue);
+        }
+      }
+
+      code {
+        color: var(--red);
+      }
     }
   }
 }

--- a/packages/theme-nord/package.json
+++ b/packages/theme-nord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webtui/theme-nord",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite build --watch",

--- a/packages/theme-nord/src/base.css
+++ b/packages/theme-nord/src/base.css
@@ -1,5 +1,5 @@
-@layer utils {
-  :root {
+@layer base {
+  [data-webtui-theme="nord"] {
     /* Polar Night */
     --nord0: #2e3440;
     --nord1: #3b4252;

--- a/packages/theme-nord/src/components/badge.css
+++ b/packages/theme-nord/src/components/badge.css
@@ -1,86 +1,88 @@
 @layer components {
-  [is-~="badge"] {
-    /* nord0 - nord3 are the same as background0 - background3 */
-    &[variant-="nord0"] {
-      --badge-color: var(--background0);
-      --badge-text: var(--foreground0);
-    }
+  [data-webtui-theme="nord"] {
+    [is-~="badge"] {
+      /* nord0 - nord3 are the same as background0 - background3 */
+      &[variant-="nord0"] {
+        --badge-color: var(--background0);
+        --badge-text: var(--foreground0);
+      }
 
-    &[variant-="nord1"] {
-      --badge-color: var(--background1);
-      --badge-text: var(--foreground0);
-    }
+      &[variant-="nord1"] {
+        --badge-color: var(--background1);
+        --badge-text: var(--foreground0);
+      }
 
-    &[variant-="nord2"] {
-      --badge-color: var(--background2);
-      --badge-text: var(--foreground0);
-    }
+      &[variant-="nord2"] {
+        --badge-color: var(--background2);
+        --badge-text: var(--foreground0);
+      }
 
-    &[variant-="nord3"] {
-      --badge-color: var(--background3);
-      --badge-text: var(--foreground0);
-    }
+      &[variant-="nord3"] {
+        --badge-color: var(--background3);
+        --badge-text: var(--foreground0);
+      }
 
-    /* nord6 - nord4 are the same as foreground0 - foreground2 */
-    &[variant-="nord6"] {
-      --badge-color: var(--foreground0);
-      --badge-text: var(--background0);
-    }
+      /* nord6 - nord4 are the same as foreground0 - foreground2 */
+      &[variant-="nord6"] {
+        --badge-color: var(--foreground0);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="nord5"] {
-      --badge-color: var(--foreground1);
-      --badge-text: var(--background0);
-    }
+      &[variant-="nord5"] {
+        --badge-color: var(--foreground1);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="nord4"] {
-      --badge-color: var(--foreground2);
-      --badge-text: var(--background0);
-    }
+      &[variant-="nord4"] {
+        --badge-color: var(--foreground2);
+        --badge-text: var(--background0);
+      }
 
-    /* accent colors */
-    &[variant-="nord7"] {
-      --badge-color: var(--nord7);
-      --badge-text: var(--background0);
-    }
+      /* accent colors */
+      &[variant-="nord7"] {
+        --badge-color: var(--nord7);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="nord8"] {
-      --badge-color: var(--nord8);
-      --badge-text: var(--background0);
-    }
+      &[variant-="nord8"] {
+        --badge-color: var(--nord8);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="nord9"] {
-      --badge-color: var(--nord9);
-      --badge-text: var(--background0);
-    }
+      &[variant-="nord9"] {
+        --badge-color: var(--nord9);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="nord10"] {
-      --badge-color: var(--nord10);
-      --badge-text: var(--background0);
-    }
+      &[variant-="nord10"] {
+        --badge-color: var(--nord10);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="nord11"] {
-      --badge-color: var(--nord11);
-      --badge-text: var(--background0);
-    }
+      &[variant-="nord11"] {
+        --badge-color: var(--nord11);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="nord12"] {
-      --badge-color: var(--nord12);
-      --badge-text: var(--background0);
-    }
+      &[variant-="nord12"] {
+        --badge-color: var(--nord12);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="nord13"] {
-      --badge-color: var(--nord13);
-      --badge-text: var(--background0);
-    }
+      &[variant-="nord13"] {
+        --badge-color: var(--nord13);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="nord14"] {
-      --badge-color: var(--nord14);
-      --badge-text: var(--background0);
-    }
+      &[variant-="nord14"] {
+        --badge-color: var(--nord14);
+        --badge-text: var(--background0);
+      }
 
-    &[variant-="nord15"] {
-      --badge-color: var(--nord15);
-      --badge-text: var(--background0);
+      &[variant-="nord15"] {
+        --badge-color: var(--nord15);
+        --badge-text: var(--background0);
+      }
     }
   }
 }

--- a/packages/theme-nord/src/components/button.css
+++ b/packages/theme-nord/src/components/button.css
@@ -1,86 +1,88 @@
 @layer components {
-  button {
-    /* nord0 - nord3 are the same as background0 - background3 */
-    &[variant-="nord0"] {
-      --button-primary: var(--background0);
-      --button-secondary: var(--foreground0);
-    }
+  [data-webtui-theme="nord"] {
+    button {
+      /* nord0 - nord3 are the same as background0 - background3 */
+      &[variant-="nord0"] {
+        --button-primary: var(--background0);
+        --button-secondary: var(--foreground0);
+      }
 
-    &[variant-="nord1"] {
-      --button-primary: var(--background1);
-      --button-secondary: var(--foreground0);
-    }
+      &[variant-="nord1"] {
+        --button-primary: var(--background1);
+        --button-secondary: var(--foreground0);
+      }
 
-    &[variant-="nord2"] {
-      --button-primary: var(--background2);
-      --button-secondary: var(--foreground0);
-    }
+      &[variant-="nord2"] {
+        --button-primary: var(--background2);
+        --button-secondary: var(--foreground0);
+      }
 
-    &[variant-="nord3"] {
-      --button-primary: var(--background3);
-      --button-secondary: var(--foreground0);
-    }
+      &[variant-="nord3"] {
+        --button-primary: var(--background3);
+        --button-secondary: var(--foreground0);
+      }
 
-    /* nord6 - nord4 are the same as foreground0 - foreground2 */
-    &[variant-="nord6"] {
-      --button-primary: var(--foreground0);
-      --button-secondary: var(--background0);
-    }
+      /* nord6 - nord4 are the same as foreground0 - foreground2 */
+      &[variant-="nord6"] {
+        --button-primary: var(--foreground0);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="nord5"] {
-      --button-primary: var(--foreground1);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="nord5"] {
+        --button-primary: var(--foreground1);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="nord4"] {
-      --button-primary: var(--foreground2);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="nord4"] {
+        --button-primary: var(--foreground2);
+        --button-secondary: var(--background0);
+      }
 
-    /* accent colors */
-    &[variant-="nord7"] {
-      --button-primary: var(--nord7);
-      --button-secondary: var(--background0);
-    }
+      /* accent colors */
+      &[variant-="nord7"] {
+        --button-primary: var(--nord7);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="nord8"] {
-      --button-primary: var(--nord8);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="nord8"] {
+        --button-primary: var(--nord8);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="nord9"] {
-      --button-primary: var(--nord9);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="nord9"] {
+        --button-primary: var(--nord9);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="nord10"] {
-      --button-primary: var(--nord10);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="nord10"] {
+        --button-primary: var(--nord10);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="nord11"] {
-      --button-primary: var(--nord11);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="nord11"] {
+        --button-primary: var(--nord11);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="nord12"] {
-      --button-primary: var(--nord12);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="nord12"] {
+        --button-primary: var(--nord12);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="nord13"] {
-      --button-primary: var(--nord13);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="nord13"] {
+        --button-primary: var(--nord13);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="nord14"] {
-      --button-primary: var(--nord14);
-      --button-secondary: var(--background0);
-    }
+      &[variant-="nord14"] {
+        --button-primary: var(--nord14);
+        --button-secondary: var(--background0);
+      }
 
-    &[variant-="nord15"] {
-      --button-primary: var(--nord15);
-      --button-secondary: var(--background0);
+      &[variant-="nord15"] {
+        --button-primary: var(--nord15);
+        --button-secondary: var(--background0);
+      }
     }
   }
 }

--- a/packages/theme-nord/src/components/typography.css
+++ b/packages/theme-nord/src/components/typography.css
@@ -1,28 +1,30 @@
 @layer components {
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    color: var(--nord14);
-  }
-
-  p,
-  blockquote,
-  li,
-  [is-~="typography-block"] {
-    a {
-      color: var(--nord7);
-      text-decoration: underline;
-
-      &:hover {
-        color: var(--nord8);
-      }
+  [data-webtui-theme="nord"] {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      color: var(--nord14);
     }
 
-    code {
-      color: var(--nord12);
+    p,
+    blockquote,
+    li,
+    [is-~="typography-block"] {
+      a {
+        color: var(--nord7);
+        text-decoration: underline;
+
+        &:hover {
+          color: var(--nord8);
+        }
+      }
+
+      code {
+        color: var(--nord12);
+      }
     }
   }
 }

--- a/web/src/layouts/Layout.astro
+++ b/web/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-webtui-theme="catppuccin">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />

--- a/web/src/pages/examples.astro
+++ b/web/src/pages/examples.astro
@@ -3,11 +3,9 @@ import Layout from '../layouts/Layout.astro';
 import Navbar from '@/components/Navbar.astro';
 import Email from '@/components/examples/Email.astro';
 import Tabs from '@/components/examples/Tabs.astro';
-import catppuccinStyle from '@webtui/theme-catppuccin?raw';
-import nordStyle from '@webtui/theme-nord?raw';
+import '@webtui/theme-nord';
+import '@webtui/theme-catppuccin';
 ---
-
-<style id="inline-theme" is:raw set:html={catppuccinStyle}></style>
 
 <Layout>
   <column self-="grow">
@@ -84,7 +82,7 @@ import nordStyle from '@webtui/theme-nord?raw';
   }
 
   @layer base {
-    html.light {
+    html[data-webtui-theme="light"] {
       --background0: #fff;
       --background1: #ddd;
       --background2: #bbb;
@@ -95,7 +93,7 @@ import nordStyle from '@webtui/theme-nord?raw';
       --foreground2: #888;
     }
 
-    html.dark {
+    html[data-webtui-theme="dark"] {
       --background0: #000;
       --background1: #222;
       --background2: #444;
@@ -132,35 +130,14 @@ import nordStyle from '@webtui/theme-nord?raw';
 </script>
 
 <!-- Theme Switcher -->
-<script define:vars={{ catppuccinStyle, nordStyle }}>
-  const themelist = document.getElementById("themelist");
-  const html = document.querySelector("html");
-
-  const appendInlineStyle = (style) => {
-    const existingInlineTheme = document.getElementById("inline-theme");
-    if (existingInlineTheme) {
-      existingInlineTheme.remove();
-    }
-    const inlineTheme = document.createElement("style");
-    inlineTheme.id = "inline-theme";
-    inlineTheme.innerHTML = style;
-    document.head.appendChild(inlineTheme);
-  };
+<script>
+  const themelist = document.getElementById("themelist")!;
+  const html = document.querySelector("html")!;
 
   const observer = new MutationObserver(() => {
-    const value = themelist.getAttribute("data-tab");
+    const value = themelist.getAttribute("data-tab") as string;
 
-    if (value === "catppuccin") {
-      appendInlineStyle(catppuccinStyle);
-    } else if (value === "nord") {
-      appendInlineStyle(nordStyle);
-    } else {
-      const existingInlineTheme = document.getElementById("inline-theme");
-      if (existingInlineTheme) {
-        existingInlineTheme.remove();
-      }
-      html.className = value;
-    }
+    html.setAttribute("data-webtui-theme", value);
   });
 
   observer.observe(themelist, {

--- a/web/src/pages/plugins/theme-catppuccin.md
+++ b/web/src/pages/plugins/theme-catppuccin.md
@@ -9,7 +9,7 @@ Provides additional variants for the listed components in the base WebTUI librar
 
 ## Installation
 
-Ensure you import the theme **after** all the other stylesheets from `@webtui/css`
+Ensure you import the theme **after** all the other stylesheets from `@webtui/css` or the styles will not be applied
 
 ```css
 @layer base, utils, components;
@@ -21,7 +21,40 @@ Ensure you import the theme **after** all the other stylesheets from `@webtui/cs
 @import '@webtui/theme-catppuccin';
 ```
 
+Set the `data-webtui-theme` attribute to the `<html>` tag
+
+```html
+<html data-webtui-theme="catppuccin-mocha">
+```
+
+To only apply the theme to a specific element, use the same attribute
+
+```html
+<html data-webtui-theme="dark">
+    <body>
+        <div data-webtui-theme="catppuccin-mocha">
+            <!-- ... -->
+        </div>
+    </body>
+</html>
+```
+
+## Flavors
+
+Supports all four Catppuccin theme flavors.
+
+```html
+<!-- `catppuccin` defaults to `catppuccin-mocha` -->
+<html data-webtui-theme="catppuccin">
+<html data-webtui-theme="catppuccin-mocha">
+<html data-webtui-theme="catppuccin-macchiato">
+<html data-webtui-theme="catppuccin-frappe">
+<html data-webtui-theme="catppuccin-latte">
+```
+
 ## Components
+
+Components affected/modified by the theme
 
 - [Typography](#typography)
 - [Badge](#badge)

--- a/web/src/pages/plugins/theme-nord.md
+++ b/web/src/pages/plugins/theme-nord.md
@@ -21,7 +21,27 @@ Ensure you import the theme **after** all the other stylesheets from `@webtui/cs
 @import '@webtui/theme-nord';
 ```
 
+Set the `data-webtui-theme` attribute to the `<html>` tag
+
+```html
+<html data-webtui-theme="nord">
+```
+
+To only apply the theme to a specific element, use the same attribute
+
+```html
+<html data-webtui-theme="dark">
+    <body>
+        <div data-webtui-theme="nord">
+            <!-- ... -->
+        </div>
+    </body>
+</html>
+```
+
 ## Components
+
+Components affected/modified by the theme
 
 - [Typography](#typography)
 - [Badge](#badge)

--- a/web/src/pages/start/theming.md
+++ b/web/src/pages/start/theming.md
@@ -68,42 +68,17 @@ Shown below is a screenshot showing the background and foreground colors of a ba
 
 ### Light & Dark
 
-`@webtui/css` ships with a very basic black-and-white theme that automatically changes based on the user's color preference
+`@webtui/css` ships with a basic light and dark theme
 
-The user's preferred color scheme can be respected with the `prefers-color-scheme` media query
-
-```css
-@layer base {
-    @media(prefers-color-scheme: dark) {
-        :root {
-            --background0: #000;
-            /* ... */
-        }
-    }
-}
-```
-
-A `class` can be used on the `html` element if you intend to change the color scheme dynamically with JavaScript
+To enable the dark theme, simply add `data-webtui-theme="dark"` to the `<html>` tag, or any element that should inherit the theme colors
 
 ```html
-<html class="dark">
-    <head>
-        <style>
-            @layer base {
-                html.dark {
-                    --background0: #000;
-                    /* ... */
-                }
-            }
-        </style>
-    </head>
-<!-- ... -->
-</html>
+<html data-webtui-theme="dark">
 ```
 
 ## Theme Plugins
 
-Theme plugins include additional color variants for individual components on top of changing the base colors
+Theme plugins change the base colors and often include additional color variants and styles for individual components
 
 ![catppuccin-badges.png](../../assets/catppuccin-badges.png)
 


### PR DESCRIPTION
Enables easier dynamic theme switching by scoping custom themes with the `data-webtui-theme` attribute

- adds multiple flavors to `@webtui/theme-catppuccin`
- removes the `prefers-color-scheme` default in the base library and allows the `dark` option to be controlled with `data-webtui-theme`
- bumps `@webtui/theme-catppuccin` to `0.0.2`
- bumps `@webtui/theme-nord` to `0.0.2`
- bumps `@webtui/css` to `0.0.2`

Fixes #31
