### PR TITLE
fix(vim): swap g/G

### DIFF
--- a/web/src/utils/vim.ts
+++ b/web/src/utils/vim.ts
@@ -75,8 +75,8 @@ export function applyVimNavigation(
 
     if (e.key === 'j' || e.key === 'ArrowDown') next.focus();
     if (e.key === 'k' || e.key === 'ArrowUp') prev.focus();
-    if (e.key === 'G') first.focus();
-    if (e.key === 'g') last.focus();
+    if (e.key === 'g') first.focus();
+    if (e.key === 'G') last.focus();
   });
 }
 


### PR DESCRIPTION
HI! Thank you for creating amazing css lib!
I found some mistake if `vim.ts`. When we use vim in normal mode, `gg` means going to the top, and `G` means to bottom. so I swapped!