### PR TITLE
chore: remove `box-="<type> contain:*"` in favor of `shear-="*"`

### DIFF
--- a/packages/css/src/utils/box.css
+++ b/packages/css/src/utils/box.css
@@ -18,9 +18,9 @@
   }
 
   /* Requires `box-` to contain `square`, `round`, or `double` in order to work */
-  [box-~="square"],
-  [box-~="round"],
-  [box-~="double"] {
+  [box-="square"],
+  [box-="round"],
+  [box-="double"] {
     --box-border-color: var(--foreground0);
 
     position: relative;
@@ -40,7 +40,7 @@
     }
 
     /* Apply border radius to the inner and outer (if present) border */
-    &[box-~="round"] {
+    &[box-="round"] {
       &::before {
         border-radius: var(--box-rounded-radius);
       }
@@ -51,7 +51,7 @@
     }
 
     /* Adds the second border to the element */
-    &[box-~="double"] {
+    &[box-="double"] {
       &::before {
         border-width: var(--box-double-border-width);
       }
@@ -70,16 +70,16 @@
     }
 
     /* Containment Variants */
-    &[box-~="contain:none"] {
+    &[shear-="both"] {
       padding-top: 0;
       padding-bottom: 0;
     }
 
-    &[box-~="contain:!top"] {
+    &[shear-="top"] {
       padding-top: 0;
     }
 
-    &[box-~="contain:!bottom"] {
+    &[shear-="bottom"] {
       padding-bottom: 0;
     }
   }

--- a/packages/rehype-tabindex/src/index.ts
+++ b/packages/rehype-tabindex/src/index.ts
@@ -57,7 +57,8 @@ const rehypeMarkdownTabIndex: Plugin<[], Root> = () => {
           type: 'element',
           tagName: 'div',
           properties: {
-            'box-': 'square contain:!top',
+            'box-': 'square',
+            'shear-': 'top',
             tabIndex: 0,
           },
           children: [figcaptionContainer, node],

--- a/web/src/components/Filter.astro
+++ b/web/src/components/Filter.astro
@@ -28,7 +28,7 @@ const docHeadings = docPages
 ---
 
 <dialog id="search-dialog">
-  <div box-="round contain:!top" id="search-content">
+  <div box-="round" shear-="top" id="search-content">
     <row align-="between">
       <span is-="badge" variant-="background0">&#xea6d; Search</span>
       <button id="close-btn" variant-="foreground0" size-="small">x</button>

--- a/web/src/components/Sidebar.astro
+++ b/web/src/components/Sidebar.astro
@@ -7,7 +7,7 @@ const categories = makeSortedCategoryEntries();
 const { pathname: urlPath } = Astro.url;
 ---
 
-<nav box-="square contain:!top" id="sidebar">
+<nav box-="square" shear-="top" id="sidebar">
   <div><span is-="badge" variant-="background0">Documentation</span></div>
   <div id="category-container">
     <div id="category-list">
@@ -31,7 +31,7 @@ const { pathname: urlPath } = Astro.url;
       }
     </div>
   </div>
-  <div box-="square contain:!top" id="keybind-container">
+  <div box-="square" shear-="top" id="keybind-container">
     <span is-="badge" variant-="background0">Shortcuts</span>
     <ul marker-="none" space-="p:1">
       <li><code>h</code> focus sidebar</li>

--- a/web/src/components/examples/Auth/Login.astro
+++ b/web/src/components/examples/Auth/Login.astro
@@ -1,10 +1,10 @@
 <column gap-="1" id="login-contents">
   <column>
-    <label box-="round contain:!top">
+    <label box-="round" shear-="top">
       <row><span is-="badge" variant-="background0">Username / Email</span></row>
       <input autofocus />
     </label>
-    <label box-="round contain:!top">
+    <label box-="round" shear-="top">
       <row><span is-="badge" variant-="background0">Password</span></row>
       <input type="password" />
     </label>

--- a/web/src/components/examples/Auth/Signup.astro
+++ b/web/src/components/examples/Auth/Signup.astro
@@ -1,18 +1,18 @@
 <column gap-="1" id="signup-contents">
   <column>
-    <label box-="round contain:!top">
+    <label box-="round" shear-="top">
       <row><span is-="badge" variant-="background0">Username</span></row>
       <input />
     </label>
-    <label box-="round contain:!top">
+    <label box-="round" shear-="top">
       <row><span is-="badge" variant-="background0">Email</span></row>
       <input type="email" />
     </label>
-    <label box-="round contain:!top">
+    <label box-="round" shear-="top">
       <row><span is-="badge" variant-="background0">Password</span></row>
       <input type="password" />
     </label>
-    <label box-="round contain:!top">
+    <label box-="round" shear-="top">
       <row><span is-="badge" variant-="background0">Confirm Password</span></row>
       <input type="password" />
     </label>

--- a/web/src/components/examples/Ecommerce/Header.astro
+++ b/web/src/components/examples/Ecommerce/Header.astro
@@ -1,5 +1,5 @@
 <column align-="center" gap-="1">
-  <row box-="square contain:none" align-="center" id="header">
+  <row box-="square" shear-="both" align-="center" id="header">
     <row><strong>terminal</strong></row>
     <div is-="separator" direction-="vertical" />
     <row gap-="1">

--- a/web/src/components/examples/Email.astro
+++ b/web/src/components/examples/Email.astro
@@ -53,7 +53,7 @@ const placeholderEmails = [
   </column>
 
   <!-- Mail Container -->
-  <column self-="grow !basis" box-="square contain:!top">
+  <column self-="grow !basis" box-="square" shear-="top">
     <row>
       <span is-="badge" variant-="background0">Mail</span>
     </row>
@@ -63,7 +63,8 @@ const placeholderEmails = [
           <column
             gap-="1"
             is-="typography-block"
-            box-="round contain:none"
+            box-="round"
+            shear-="both"
             class="mail-item"
           >
             <row align-="between">
@@ -94,7 +95,7 @@ const placeholderEmails = [
   </column>
 
   <!-- Mail Preview -->
-  <column self-="grow !basis" box-="square contain:!top">
+  <column self-="grow !basis" box-="square" shear-="top">
     <row>
       <span is-="badge" variant-="background0">Preview</span>
     </row>

--- a/web/src/layouts/Doc.astro
+++ b/web/src/layouts/Doc.astro
@@ -53,7 +53,7 @@ if (headings.length > 0) {
       <div id="sidebar-container" class="mobile-hidden">
         <Sidebar />
       </div>
-      <article box-="square contain:!top">
+      <article box-="square" shear-="top">
         <header is-="row" align-="between">
           <div is-="badge" variant-="background0">
             <h1>{frontmatter.title}</h1>
@@ -69,7 +69,8 @@ if (headings.length > 0) {
                     <a
                       href={`/${prevDoc.id}`}
                       class="prev"
-                      box-="round contain:!top"
+                      box-="round"
+                      shear-="top"
                       tabindex="0"
                     >
                       <div is-="typography-block">
@@ -88,7 +89,8 @@ if (headings.length > 0) {
                     <a
                       href={`/${nextDoc.id}`}
                       class="next"
-                      box-="round contain:!top"
+                      box-="round"
+                      shear-="top"
                       tabindex="0"
                     >
                       <row align-="start end" is-="typography-block">

--- a/web/src/pages/components/input.mdx
+++ b/web/src/pages/components/input.mdx
@@ -52,7 +52,7 @@ body {
 
 ### Box Borders
 
-The `box-` utility cannot be used directly on an `<input>` element because inputs don't support pseudo-elements
+The `box-` utility cannot be used directly on `<input>` elements because inputs don't support pseudo-elements
 
 Instead, wrap an `<input>` with a `<label box-="*">` or use a `contenteditable` element
 
@@ -62,7 +62,7 @@ Instead, wrap an `<input>` with a `<label box-="*">` or use a `contenteditable` 
         badgeStyle,
         boxStyle, 
     ]}
-css={`
+    css={`
 input {
     background-color: var(--background0);
 }
@@ -74,8 +74,7 @@ body {
 .row {
     display: flex;
 }`}
-html={`
-<label box-="round contain:!top">
+    html={`<label box-="round" shear-="top">
     <div clas="row">
         <span is-="badge" variant-="background0">Username</span>
     </div>

--- a/web/src/pages/examples.astro
+++ b/web/src/pages/examples.astro
@@ -39,7 +39,7 @@ const themes = {
       <div data-tab="all">[All Components example Coming Soon]</div>
     </div>
 
-    <column box-="square contain:!top">
+    <column box-="square" shear-="top">
       <row><span is-="badge" variant-="background0">Settings</span></row>
       <row class="wrap" gap-="1" space-="px:1" align-="center between">
         <Tabs id="tabslist">

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -18,7 +18,7 @@ import Navbar from '@/components/Navbar.astro';
               WebTUI is a modular CSS library that brings the beauty of Terminal
               UIs to the browser
             </p>
-            <div id="start-links" box-="square contain:!top">
+            <div id="start-links" box-="square" shear-="top">
               <row>
                 <span is-="badge" variant-="background0" tabindex="0"
                   >Contents</span

--- a/web/src/pages/start/ascii-boxes.mdx
+++ b/web/src/pages/start/ascii-boxes.mdx
@@ -31,7 +31,7 @@ The `box-` utility utilizes CSS `::before` and `::after` pseudo-elements to mimi
     display: flex; 
     justify-content: flex-end; 
 }`}
-    html={`<div box-="square contain:none">
+    html={`<div box-="square" shear-="both">
     <div class="header">
         <span is-="badge" variant-="background0">top-left</span>
         <span is-="badge" variant-="background0">top-right</span>
@@ -70,7 +70,7 @@ Using `box="..."` **will not work**
 
 ## Examples
 
-### Box Border Types
+### Border Types
 
 <Example 
     stylesheets={[
@@ -80,12 +80,13 @@ Using `box="..."` **will not work**
 <div box-="square">Square</div>
 <div box-="round">Round</div>
 <div box-="double">Double</div>
+<div box-="double round">Double + Round</div>
 `}
 />
 
-### Containment
+### Shearing
 
-Choose whether to contain the top and/or bottom lines of the box
+Shearing off top/bottom padding allows overlaying content over the top and/or bottom edges of the box
 
 <Example 
     stylesheets={[
@@ -102,8 +103,8 @@ span {
     padding: 0 1ch;
 }`}
     html={`
-<!-- Do not contain the top row -->
-<div box-="square contain:!top">
+<!-- Shear off the top edge's padding -->
+<div box-="square" shear-="top">
     <div class="header">
         <span>Left</span>
         <span>Right</span>
@@ -111,8 +112,8 @@ span {
     Caption on Top
 </div>
 
-<!-- Do not contain the bottom row -->
-<div box-="square contain:!bottom">
+<!-- Shear off the bottom edge's padding -->
+<div box-="square" shear-="bottom">
     Caption on Bottom
     <div class="header">
         <span>Left</span>
@@ -120,8 +121,8 @@ span {
     </div>
 </div>
 
-<!-- Do not contain the top or bottom rows -->
-<div box-="square contain:none">
+<!-- Shear off the padding of both top & bottom edges -->
+<div box-="square" shear-="both">
     <div class="header">
         <span>Left</span>
         <span>Right</span>
@@ -135,72 +136,33 @@ span {
 `}
 />
 
-## Properties
+## Reference
 
-Elements with the `box-` attribute can be customized via **Custom CSS properties** [[MDN Reference]](https://developer.mozilla.org/en-US/docs/Web/CSS/@property)
+### Properties
 
-### `--box-border-color`
+- `--box-border-color`: The border color of the box
+- `--box-rounded-radius`: The border radius of `round` boxes
+- `--box-border-width`: The border width for `square` and `round` boxes
+- `--box-double-border-width`: The width of boxes with `double` borders
 
-The border color of the box
-
-- Syntax: `<color>`
-- Default Value: `var(--foreground0)`
-
-```html
-<style>
-  #my-box {
-    --box-border-color: red;
-  }
-</style>
-
-<div box-="square" id="my-box"></div>
+```css
+#my-box {
+    --box-border-color: cyan;
+    --box-rounded-radius: 8px;
+    --box-border-width: 1px;
+    --box-double-border-width: 1px;
+}
 ```
 
-### `--box-rounded-radius`
+### Extending
 
-The border radius of `round` boxes
+To extend the Box stylesheet, define a CSS rule on the `utils` layer
 
-- Syntax: `<length>`
-- Default Value: `4px`
-
-```html
-<style>
-  #my-box {
-    --box-rounded-radius: 10px;
-  }
-</style>
-
-<div box-="round" id="my-box"></div>
-```
-
-### `--box-border-width`
-
-The border width for `square` and `round` boxes
-
-- Syntax: `<length>`
-- Default Value: `2px`
-
-```html
-<style>
-  #my-box {
-    --box-border-width: 10px;
-  }
-</style>
-
-<div box-="square" id="my-box"></div>
-```
-
-### `--box-double-border-width`
-
-The width of boxes with `double` borders
-
-- Syntax: `<length>`
-- Default Value: `1px`
-
-```html
-<style>
-  #my-box {
-    --box-double-border-width: 10px;
-  }
-</style>
-```
+```css
+@layer utils {
+    [box-~="square"], 
+    [box-~="round"],
+    [box-~="double"] {
+        /* ... */
+    }
+}


### PR DESCRIPTION
Closes #66

- Removes the `contain:*` property from the `box-` utility
- Adds a new `shear-="*"` property to the `box-` utility
- Migrates site to use the new `shear-="*"` property

Do not merge until 0.1.x release
