### PR TITLE
feat: tooltip component

### DIFF
--- a/packages/css/src/components/popover.css
+++ b/packages/css/src/components/popover.css
@@ -11,7 +11,7 @@
     initial-value: 0;
   }
 
-  details[is-="popover"] {
+  details[is-~="popover"] {
     --popover-backdrop-color: transparent;
 
     position: relative;

--- a/packages/css/src/components/tooltip.css
+++ b/packages/css/src/components/tooltip.css
@@ -1,0 +1,81 @@
+@layer components {
+  @property --tooltip-offset-x {
+    syntax: "<length>";
+    inherits: true;
+    initial-value: 0;
+  }
+
+  @property --tooltip-offset-y {
+    syntax: "<length>";
+    inherits: true;
+    initial-value: 0;
+  }
+
+  @property --tooltip-delay {
+    syntax: "<time>";
+    inherits: true;
+    initial-value: 0.5s;
+  }
+
+  [is-~="tooltip"] {
+    position: relative;
+
+    & > [is-~="tooltip-trigger"] {
+      cursor: pointer;
+    }
+
+    [is-~="tooltip-content"] {
+      opacity: 0;
+      transition: all 0s linear 0s;
+      transform: scale(0);
+      overflow: hidden;
+      position: absolute;
+    }
+
+    &:has([is-~="tooltip-trigger"]:hover) > [is-~="tooltip-content"],
+    &:has([is-~="tooltip-trigger"]:focus) > [is-~="tooltip-content"] {
+      opacity: 1;
+      z-index: 2;
+      transform: scale(1);
+      transition-delay: var(--tooltip-delay);
+
+      &[position-~="baseline-left"],
+      &:not([position-]) {
+        left: 0%;
+      }
+
+      &[position-~="baseline-right"] {
+        left: 100%;
+        translate: -100%;
+      }
+
+      &[position-~="left"] {
+        left: calc(var(--tooltip-offset-x) * -1);
+        translate: -100%;
+      }
+
+      &[position-~="right"] {
+        left: calc(100% + var(--tooltip-offset-x));
+      }
+
+      &[position-~="baseline-top"] {
+        top: 0%;
+      }
+
+      &[position-~="baseline-bottom"] {
+        top: 100%;
+        transform: translateY(-100%);
+      }
+
+      &[position-~="top"],
+      &:not([position-]) {
+        top: calc(var(--tooltip-offset-y) * -1);
+        transform: translateY(-100%);
+      }
+
+      &[position-~="bottom"] {
+        top: calc(100% + var(--tooltip-offset-y));
+      }
+    }
+  }
+}

--- a/packages/css/src/full.css
+++ b/packages/css/src/full.css
@@ -18,3 +18,4 @@
 @import "./components/separator.css";
 @import "./components/radio.css";
 @import "./components/pre.css";
+@import "./components/tooltip.css";

--- a/web/src/pages/components/popover.mdx
+++ b/web/src/pages/components/popover.mdx
@@ -55,7 +55,7 @@ body {
     flex-direction: column;
     gap: 1lh;
     justify-content: center;
-height: 100vh;
+    height: 100vh;
 }
 .row {
     display: flex;
@@ -177,47 +177,6 @@ body {
 <p>This appears behind the backdrop</p>`}
 />
 
-### Offset
-
-<Example 
-    stylesheets={[
-        popoverStyle, 
-    ]}
-css={`
-body {
-    display: flex;
-    flex-direction: column;
-    gap: 1lh;
-}
-.row {
-    display: flex;
-}
-details[is-="popover"] {
-    --popover-offset-x: 1ch;
-    --popover-offset-y: 1lh;
-}
-.popover-content {
-    background-color: var(--background1);
-    white-space: nowrap;
-    padding: 1lh 1ch;
-}
-`}
-html={`
-<div class="row">
-<details is-="popover" position-="bottom">
-    <summary>Click Me</summary>
-    <div class="popover-content">Offset y 1lh</div>
-</details>
-</div>
-<div class="row">
-<details is-="popover" position-="right baseline-top">
-    <summary>Click Me as well</summary>
-    <div class="popover-content">Offset x 1ch</div>
-</details>
-</div>
-`}
-/>
-
 ## Caveats
 
 Elements using the `box-` utility that appear **after** the popover in the html markup will appear above the popover content no matter what z-index you provide
@@ -257,7 +216,6 @@ As a workaround, you can set the `flex-direction` to `row-reverse` or `column-re
     </details>
 </div>
 ```
-
 
 ## Reference
 

--- a/web/src/pages/components/tooltip.mdx
+++ b/web/src/pages/components/tooltip.mdx
@@ -1,0 +1,224 @@
+---
+layout: "@/layouts/Doc.astro"
+title: Tooltip
+---
+
+import Example from '@/components/Example.astro';
+import tooltipStyle from '@webtui/css/components/tooltip.css?raw';
+import buttonStyle from '@webtui/css/components/button.css?raw';
+import badgeStyle from '@webtui/css/components/badge.css?raw';
+
+Displays information in a popup when a specified trigger is focused or hovered over
+
+<Example 
+    stylesheets={[
+        tooltipStyle, 
+buttonStyle,
+        badgeStyle
+    ]}
+css={`
+body {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+}
+[is-="tooltip-content"] {
+    background-color: var(--background1);
+    padding: 1lh 1ch;
+    width: 100%;
+}
+`}
+    html={`
+<div is-="tooltip">
+    <span is-="tooltip-trigger badge" variant-="background2">Hover me</span>
+    <div is-="tooltip-content">
+        <p>Tooltip content</p>
+    </div>
+</div>
+`}
+/>
+
+## Import
+
+```css
+@import "@webtui/css/components/tooltip.css";
+```
+
+## Usage
+
+```html
+<div is-="tooltip">
+    <div is-="tooltip-trigger">Tooltip trigger</div>
+    <div is-="tooltip-content">
+        <p>Tooltip content</p>
+    </div>
+</div>
+```
+
+## Examples
+
+### Positioning
+
+<Example 
+    stylesheets={[
+        tooltipStyle, 
+        badgeStyle,
+    ]}
+css={`
+body {
+    display: flex;
+    flex-direction: column;
+    gap: 1lh;
+    justify-content: center;
+    height: 100vh;
+}
+.row {
+    display: flex;
+    gap: 1ch;
+aling-items: center;
+    justify-content: center;
+}
+[is-="tooltip-content"] {
+    background-color: var(--background1);
+    padding: 1lh 1ch;
+}
+`}
+    html={`
+<div class="row">
+    <div is-="tooltip">
+        <div is-="tooltip-trigger badge" variant-="background2">BR ↘</div>
+        <div is-="tooltip-content" position-="bottom right">
+            <p>Tooltip content</p>
+        </div>
+    </div>
+    <div is-="tooltip">
+        <div is-="tooltip-trigger badge" variant-="background2">BL ↙</div>
+        <div is-="tooltip-content" position-="bottom left">
+            <p>Tooltip content</p>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div is-="tooltip">
+        <span is-="tooltip-trigger badge" variant-="background2">TR ↗</span>
+        <div is-="tooltip-content" position-="top right">
+            <p>Tooltip content</p>
+        </div>
+    </div>
+    <div is-="tooltip">
+        <span is-="tooltip-trigger badge" variant-="background2">TL ↖</span>
+        <div is-="tooltip-content" position-="top left">
+            <p>Tooltip content</p>
+        </div>
+    </div>
+</div>
+`}
+/>
+
+Use `baseline-*` values to position the content relative to the edges of the tooltip
+
+<Example 
+    stylesheets={[
+        tooltipStyle, 
+        badgeStyle,
+    ]}
+css={`
+body {
+    display: flex;
+    flex-direction: column;
+    gap: 1lh;
+    justify-content: center;
+    height: 100vh;
+}
+.row {
+    display: flex;
+    gap: 1ch;
+aling-items: center;
+    justify-content: center;
+}
+[is-="tooltip-content"] {
+    background-color: var(--background1);
+    padding: 1lh 1ch;
+}
+`}
+    html={`
+<div class="row">
+    <div is-="tooltip">
+        <div is-="tooltip-trigger badge" variant-="background2">Bottom Baseline-Right</div>
+        <div is-="tooltip-content" position-="bottom baseline-right">
+            <p>Tooltip content</p>
+        </div>
+    </div>
+    <div is-="tooltip">
+        <div is-="tooltip-trigger badge" variant-="background2">Bottom Baseline-Left</div>
+        <div is-="tooltip-content" position-="bottom baseline-left">
+            <p>Tooltip content</p>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div is-="tooltip">
+        <span is-="tooltip-trigger badge" variant-="background2">Right Baseline-Top</span>
+        <div is-="tooltip-content" position-="right baseline-top">
+            <p>Tooltip content</p>
+        </div>
+    </div>
+    <div is-="tooltip">
+        <span is-="tooltip-trigger badge" variant-="background2">Left Baseline-Top</span>
+        <div is-="tooltip-content" position-="left baseline-top">
+            <p>Tooltip content</p>
+        </div>
+    </div>
+</div>
+`}
+/>
+
+This image from the [Popover](/components/popover) page shows the values and positions that can be used in the `position-` property
+
+![popover-positioning.png](../../assets/popover-positioning.png)
+
+## Reference
+
+### Properties
+
+- `--tooltip-offset-x`: The horizontal offset of the tooltip
+- `--tooltip-offset-y`: The vertical offset of the tooltip
+- `--tooltip-delay`: The delay before the tooltip appears
+
+```css
+#my-custom-tooltip {
+    --tooltip-offset-x: 1ch;
+    --tooltip-offset-y: 1lh;
+    --tooltip-delay: 0.5s;
+}
+```
+
+### Extending
+
+To extend the Tooltip stylesheet, define a CSS rule on the `components` layer
+
+```css
+@layer components {
+    [is-~="tooltip"] {
+        &[variant-="inverted"] {
+            /* ... */
+        }
+
+        /* ... */
+    }
+}
+```
+
+### Scope
+
+- All elements with the `is-~="tooltip"` selector
+- Children of `is-="tooltip"` with the `is-~="tooltip-trigger"` selector
+- Children of `is-="tooltip"` with the `is-~="tooltip-content"` selector
+
+```css
+[is-~="tooltip"] { 
+    [is-~="tooltip-trigger"] { /* ... */ }
+    [is-~="tooltip-content"] { /* ... */ }
+}
+```


### PR DESCRIPTION
Addresses #26

- Adds a tooltip component and its respective documentation.
- Removes an unnecessary portion of the popover docs.
- Fixes the `is-` property on the popover component to be more polymorphic
