### PR TITLE
Fix: Duplicate form field id in the same form

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -59,7 +59,6 @@ import Navbar from '@/components/Navbar.astro';
       <input id="cmdline" aria-label="vim cmdline" />
     </column>
   </row>
-  <Filter />
 </Layout>
 
 <style>


### PR DESCRIPTION
Fixes #73

## What does this PR do?

This PR fixes a tiny bug of a double usage of an `id`. It was caused by a double usage of the `Filter` component in the `index.astro` file plus in the `Navbar` component.

## Checklist

- [x] I have read the [Contributing Guide](https://webtui.ironclad.sh/contributing/contributing)
- [x] My Pull Request abides by the [Style Guide](https://webtui.ironclad.sh/contributing/style-guide)
