### PR TITLE
Remove forgotten artifact import in index

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,5 +1,4 @@
 ---
-import Filter from '@/components/Filter.astro';
 import Layout from '../layouts/Layout.astro';
 import Navbar from '@/components/Navbar.astro';
 ---


### PR DESCRIPTION
Fixes #73

## What does this PR do?
Remove forgotten import of unused `Filter` component in the `index.astro` file.

> Follow up PR of
> * #74

## Checklist

- [x] I have read the [Contributing Guide](https://webtui.ironclad.sh/contributing/contributing)
- [x] My Pull Request abides by the [Style Guide](https://webtui.ironclad.sh/contributing/style-guide)
