### PR TITLE
Fix vim statusline: last element reach bottom

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -167,7 +167,7 @@ import Navbar from '@/components/Navbar.astro';
 
     if (index === 0) {
       percentage.innerText = "Top";
-    } else if (index === headerElements.length-1) {
+    } else if (index === headerElements.length - 1) {
       percentage.innerText = "Bot";
     } else {
       const percent = Math.round((index / headerElements.length) * 100);

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -167,7 +167,7 @@ import Navbar from '@/components/Navbar.astro';
 
     if (index === 0) {
       percentage.innerText = "Top";
-    } else if (index === headerElements.length) {
+    } else if (index === headerElements.length-1) {
       percentage.innerText = "Bot";
     } else {
       const percent = Math.round((index / headerElements.length) * 100);


### PR DESCRIPTION
Fixes #78 

## What does this PR do?
Small fix to make the vim statusline display `Bot` when user actually reaches last header.
<img width="938" alt="Screenshot 2025-05-25 at 11 08 30" src="https://github.com/user-attachments/assets/a10046fb-1e2c-4674-9efd-c69a0b981142" />

## Checklist

- [x] I have read the [Contributing Guide](https://webtui.ironclad.sh/contributing/contributing)
- [x] My Pull Request abides by the [Style Guide](https://webtui.ironclad.sh/contributing/style-guide)
