### PR TITLE
feat: switch component

### DIFF
--- a/packages/css/src/components/checkbox.css
+++ b/packages/css/src/components/checkbox.css
@@ -1,5 +1,5 @@
 @layer components {
-  input[type="checkbox"] {
+  input[type="checkbox"]:not([is-="switch"]) {
     appearance: none;
     -webkit-appearance: none;
     -moz-appearance: none;
@@ -8,7 +8,6 @@
     width: 3ch;
     min-width: initial;
     vertical-align: text-top;
-    cursor: pointer;
     color: var(--foreground2);
     font-family: var(--font-family);
     font-size: var(--font-size);
@@ -16,7 +15,7 @@
     outline: none;
   }
 
-  input[type="checkbox"]::before {
+  input[type="checkbox"]:not([is-="switch"])::before {
     content: "";
     position: absolute;
     inset: 0;
@@ -28,32 +27,29 @@
     background: var(--background1);
   }
 
-  input[type="checkbox"]:checked::before {
+  input[type="checkbox"]:not([is-="switch"]):checked::before {
     content: "X";
   }
 
-  label:has(input[type="checkbox"]) {
+  label:has(input[type="checkbox"]:not([is-="switch"])) {
     display: inline-flex;
     align-items: flex-start;
     gap: 1ch;
-    cursor: pointer;
     max-width: fit-content;
   }
 
-  label:has(input[type="checkbox"]:focus) {
+  label:has(input[type="checkbox"]:not([is-="switch"]):focus) {
     font-weight: bold;
     text-decoration: underline;
   }
 
-  input[type="checkbox"]:disabled {
+  input[type="checkbox"]:not([is-="switch"]):disabled {
     color: var(--foreground2);
-    cursor: default;
     pointer-events: none;
   }
 
-  label:has(input[type="checkbox"]:disabled) {
+  label:has(input[type="checkbox"]:not([is-="switch"]):disabled) {
     color: var(--foreground2);
     text-decoration: line-through;
-    cursor: default;
   }
 }

--- a/packages/css/src/components/popover.css
+++ b/packages/css/src/components/popover.css
@@ -38,7 +38,6 @@
           inset: 0;
           z-index: 1;
           background-color: var(--popover-backdrop-color);
-          cursor: default;
         }
 
         &::marker {

--- a/packages/css/src/components/radio.css
+++ b/packages/css/src/components/radio.css
@@ -8,7 +8,6 @@
     width: 3ch;
     min-width: initial;
     vertical-align: text-top;
-    cursor: pointer;
     color: var(--foreground2);
     font-family: var(--font-family);
     font-size: var(--font-size);
@@ -36,7 +35,6 @@
     display: inline-flex;
     align-items: flex-start;
     gap: 1ch;
-    cursor: pointer;
     max-width: fit-content;
   }
 
@@ -47,13 +45,11 @@
 
   input[type="radio"]:disabled {
     color: var(--foreground2);
-    cursor: default;
     pointer-events: none;
   }
 
   label:has(input[type="radio"]:disabled) {
     color: var(--foreground2);
     text-decoration: line-through;
-    cursor: default;
   }
 }

--- a/packages/css/src/components/switch.css
+++ b/packages/css/src/components/switch.css
@@ -1,0 +1,85 @@
+@layer components {
+  input[type="checkbox"][is-="switch"] {
+    --switch-thumb-color: var(--foreground0);
+    --switch-track-color: var(--background1);
+
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    display: inline-block;
+    position: relative;
+    width: 4ch;
+    height: 1lh;
+    min-width: initial;
+    vertical-align: text-top;
+    font-family: var(--font-family);
+    font-size: var(--font-size);
+    line-height: var(--line-height);
+    outline: none;
+
+    &::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 4ch;
+      height: 1lh;
+      background: var(--switch-track-color);
+    }
+
+    &::after {
+      content: "";
+      position: absolute;
+      width: 2ch;
+      height: 1lh;
+      background: var(--switch-thumb-color);
+    }
+
+    &:checked::after {
+      right: 0;
+    }
+
+    &:disabled {
+      --switch-thumb-color: var(--foreground2);
+      pointer-events: none;
+    }
+
+    &[size-="small"] {
+      width: 2ch;
+
+      &::before {
+        width: 2ch;
+      }
+
+      &::after {
+        width: 1ch;
+      }
+    }
+
+    &[bar-="thin"]::before {
+      height: 0.5lh;
+    }
+
+    &[bar-="line"]::before {
+      height: 2px;
+    }
+  }
+
+  label:has(input[type="checkbox"][is-="switch"]) {
+    display: inline-flex;
+    align-items: flex-start;
+    gap: 1ch;
+    max-width: fit-content;
+  }
+
+  label:has(input[type="checkbox"][is-="switch"]:focus) {
+    font-weight: bold;
+    text-decoration: underline;
+  }
+
+  label:has(input[type="checkbox"][is-="switch"]:disabled) {
+    color: var(--foreground2);
+    text-decoration: line-through;
+  }
+}

--- a/packages/css/src/components/tooltip.css
+++ b/packages/css/src/components/tooltip.css
@@ -20,10 +20,6 @@
   [is-~="tooltip"] {
     position: relative;
 
-    & > [is-~="tooltip-trigger"] {
-      cursor: pointer;
-    }
-
     [is-~="tooltip-content"] {
       opacity: 0;
       transition: all 0s linear 0s;

--- a/web/src/pages/components/checkbox.mdx
+++ b/web/src/pages/components/checkbox.mdx
@@ -79,7 +79,7 @@ To extend the Checkbox stylesheet, define a CSS rule on the `components` layer
 
 ```css
 @layer components {
-  input[type="checkbox"] {
+  input[type="checkbox"]:not([is-="switch"]) {
     /* ... */
   }
 }
@@ -87,10 +87,10 @@ To extend the Checkbox stylesheet, define a CSS rule on the `components` layer
 
 ### Scope
 
-- All native `<input type="checkbox">` elements
+- All native `<input type="checkbox">` elements without `is-="switch"`
 
 ```css
-input[type="checkbox"] {
+input[type="checkbox"]:not([is-="switch"]) {
   /* ... */
 }
 ```

--- a/web/src/pages/components/switch.mdx
+++ b/web/src/pages/components/switch.mdx
@@ -1,0 +1,156 @@
+---
+layout: "@/layouts/Doc.astro"
+title: Switch
+---
+
+import Example from '@/components/Example.astro';
+import switchStyle from '@webtui/css/components/switch.css?raw';
+
+Displays a switch
+
+<Example 
+    stylesheets={[
+        switchStyle, 
+    ]}
+    html={`<label>
+    <input type="checkbox" is-="switch" />
+    Switch
+</label>`}
+/>
+
+## Import
+
+```css
+@import "@webtui/css/components/switch.css";
+```
+
+## Usage
+
+```html
+<label>
+    <input type="checkbox" is-="switch" />
+    Switch
+</label>
+```
+
+## Examples
+
+### Checked/Unchecked
+
+Use the `checked` attribute to set the initial value of the switch checkbox
+
+<Example 
+    stylesheets={[
+        switchStyle, 
+    ]}
+html={`
+<label>
+    <input type="checkbox" is-="switch" />
+    Unchecked
+</label>
+<label>
+    <input type="checkbox" is-="switch" checked />
+    Checked
+</label>
+`}
+/>
+
+### Disabled
+
+Use the `disabled` attribute to disable the switch
+
+<Example 
+    stylesheets={[
+        switchStyle, 
+    ]}
+html={`
+<label>
+    <input type="checkbox" is-="switch" disabled />
+    Disabled
+</label>
+<label>
+    <input type="checkbox" is-="switch" checked disabled />
+    Checked Disabled
+</label>
+`}
+/>
+
+### Size
+
+Use the `size-` attribute to set the size of the switch
+
+<Example 
+    stylesheets={[
+        switchStyle, 
+    ]}
+html={`
+<label>
+    <input type="checkbox" is-="switch" size-="small" />
+    Small
+</label>
+<label>
+    <input type="checkbox" is-="switch" />
+    Default
+</label>
+`}
+/>
+
+### Bar Size
+
+Set the `bar-` attribute to `thin` or `line` to set the size of the switch bar
+
+<Example 
+    stylesheets={[
+        switchStyle, 
+    ]}
+html={`
+<label>
+    <input type="checkbox" is-="switch" />
+    Default
+</label>
+<label>
+    <input type="checkbox" is-="switch" bar-="thin" />
+    Thin Bar
+</label>
+<label>
+    <input type="checkbox" is-="switch" bar-="line" />
+    Line Bar
+</label>
+`}
+/>
+
+## Reference
+
+### Properties
+
+- `--switch-thumb-color`: The color of the switch thumb
+- `--switch-track-color`: The color of the switch track
+
+```css
+#my-switch-input {
+  --switch-thumb-color: var(--foreground0);
+  --switch-track-color: var(--background1);
+}
+```
+
+### Extending
+
+To extend the Checkbox stylesheet, define a CSS rule on the `components` layer
+
+```css
+@layer components {
+  input[type="checkbox"][is-="switch"] {
+    /* ... */
+  }
+}
+```
+
+### Scope
+
+- All native `<input type="checkbox">` elements with `is-="switch"`
+
+```css
+input[type="checkbox"][is-="switch"] {
+  /* ... */
+}
+```


### PR DESCRIPTION
Addresses #18

- Adds a switch component
- Makes the checkbox styles not affect checkbox inputs of `[type="checkbox"]`
- Removes `cursor: *` from all styles in the library