### PR TITLE
feat: add half-block padding size variant for pre component

### DIFF
--- a/packages/css/src/components/pre.css
+++ b/packages/css/src/components/pre.css
@@ -1,7 +1,9 @@
 @layer components {
   pre,
   [is-~="pre"] {
-    background-color: var(--background1);
+    --pre-background: var(--background1);
+
+    background-color: var(--pre-background);
     white-space: pre-wrap;
     color: var(--foreground0);
     font-family: var(--font-family);
@@ -10,17 +12,23 @@
     line-height: var(--line-height);
     outline: none;
     border: none;
+    padding: 1lh 1ch;
 
     &[size-="small"] {
-      padding: 0 0;
-    }
-
-    &:not([size-]) {
       padding: 0 1ch;
     }
 
-    &[size-="large"] {
-      padding: 1lh 1ch;
+    &:not([size-]) {
+      background-color: transparent;
+      background-image: linear-gradient(
+        to bottom,
+        transparent,
+        transparent 0.5lh,
+        var(--pre-background) 0.5lh,
+        var(--pre-background) calc(100% - 0.5lh),
+        transparent calc(100% - 0.5lh),
+        transparent
+      );
     }
   }
 }

--- a/web/src/pages/components/pre.mdx
+++ b/web/src/pages/components/pre.mdx
@@ -47,6 +47,16 @@ Displays preformatted text
 
 ## Reference
 
+### Properties
+
+- `--pre-background`: Background color of the pre element
+
+```css
+#my-pre {
+    --pre-background: var(--background1);
+}
+```
+
 ### Extending
 
 To extend the Pre stylesheet, define a CSS rule on the `components` layer

--- a/web/src/pages/start/changelog.mdx
+++ b/web/src/pages/start/changelog.mdx
@@ -5,6 +5,32 @@ title: "Changelog"
 
 import Example from '@/components/Example.astro';
 import buttonStyle from '@webtui/css/components/button.css?raw';
+import preStyle from '@webtui/css/components/pre.css?raw';
+
+## 0.1.1
+
+- Adds the [Switch Component](/components/switch)
+- Adds a half-block height variant to the [Pre Component](/components/pre) so it doesn't appear so tall
+
+### Migration Guide from 0.1.0
+
+#### Pre Size
+
+The default size for `pre` elements has been changed to make them shorter
+
+<Example 
+    stylesheets={[
+        preStyle, 
+    ]}
+    css={`body {
+    display: flex;
+    flex-direction: column;
+    gap: 1ch;
+}`}
+    html={`<pre size-="small">Small</pre>
+<pre>Default</pre>
+<pre size-="large">Large (old default)</pre>`}
+/>
 
 ## 0.1.0
 


### PR DESCRIPTION
The default variant of the pre component now has a half-block padding size
