### PR TITLE
chore: don't hide tooltip if content is hovered

### DIFF
--- a/packages/css/src/components/tooltip.css
+++ b/packages/css/src/components/tooltip.css
@@ -29,7 +29,8 @@
     }
 
     &:has([is-~="tooltip-trigger"]:hover) > [is-~="tooltip-content"],
-    &:has([is-~="tooltip-trigger"]:focus) > [is-~="tooltip-content"] {
+    &:has([is-~="tooltip-trigger"]:focus) > [is-~="tooltip-content"],
+    &:has([is-~="tooltip-content"]:hover) > [is-~="tooltip-content"] {
       opacity: 1;
       z-index: 2;
       transform: scale(1);

--- a/web/src/pages/start/changelog.mdx
+++ b/web/src/pages/start/changelog.mdx
@@ -11,6 +11,7 @@ import preStyle from '@webtui/css/components/pre.css?raw';
 
 - Adds the [Switch Component](/components/switch)
 - Adds a half-block height variant to the [Pre Component](/components/pre) so it doesn't appear so tall
+- Tooltips remain visible when you hover over their content
 
 ### Migration Guide from 0.1.0
 


### PR DESCRIPTION
Continue to show the tooltip content when the mouse is over the content
