### PR TITLE
feat: add ctrl-o, ctrl-i vim motions to docs

### DIFF
--- a/web/src/layouts/Doc.astro
+++ b/web/src/layouts/Doc.astro
@@ -155,6 +155,18 @@ if (headings.length > 0) {
       return;
     }
 
+    // ctrl-o -> "navigate out"
+    if (e.key === 'o' && e.ctrlKey) {
+      e.preventDefault();
+      window.history.back();
+    }
+
+    // ctrl-i -> "navigate in"
+    if (e.key === 'i' && e.ctrlKey) {
+      e.preventDefault();
+      window.history.forward();
+    }
+
     if (e.key === "l") {
       const elementToFocus =
         currentElement ?? findFirstFocusableElement() ?? null;


### PR DESCRIPTION
Fixes https://github.com/webtui/webtui/issues/117

## What does this PR do?

Tiny PR. Makes going forward/back easier with vim motions.

* `ctrl-o`: navigate back ("out")
* `ctrl-i`: navigate forward ("in")

## Checklist

- [x] I have read the [Contributing Guide](https://webtui.ironclad.sh/contributing/contributing)
- [x] My Pull Request abides by the [Style Guide](https://webtui.ironclad.sh/contributing/style-guide)
