### PR TITLE
docs: fix misnamed dialog example text

### DIFF
--- a/web/src/pages/components/dialog.mdx
+++ b/web/src/pages/components/dialog.mdx
@@ -98,7 +98,7 @@ html={`<div class="row">
     <dialog id="start" position-="start" popover>start</dialog>
     <button popovertarget="start">start</button>
 
-    <dialog id="center-start" position-="center start" popover>end start</dialog>
+    <dialog id="center-start" position-="center start" popover>center start</dialog>
     <button popovertarget="center-start">center start</button>
 
     <dialog id="end-start" position-="end start" popover>end start</dialog>


### PR DESCRIPTION
## What does this PR do?

This PR fixes the text of a misnamed `dialog` example in the docs

## Checklist

- [x] I have read the [Contributing Guide](https://webtui.ironclad.sh/contributing/contributing)
- [x] My Pull Request abides by the [Style Guide](https://webtui.ironclad.sh/contributing/style-guide)
