### PR TITLE
Add initial values for progress-value and progress-max

### DIFF
--- a/packages/css/src/components/progress.css
+++ b/packages/css/src/components/progress.css
@@ -2,11 +2,13 @@
     @property --progress-value {
         syntax: '<number>';
         inherits: false;
+        initial-value: 0;
     }
 
     @property --progress-max {
         syntax: '<number>';
         inherits: false;
+        initial-value: 100;
     }
 
     [is-~='progress'] {


### PR DESCRIPTION
LightningCSS is mean to my SvelteKit builds when initial value isn't set for these

Fixes #171

## What does this PR do?
Fixes build issues from LightningCSS when using Vite (I think - might just be SvelteKit)

## Checklist

- [X] I have read the [Contributing Guide](https://webtui.ironclad.sh/contributing/contributing)
- [X] My Pull Request abides by the [Style Guide](https://webtui.ironclad.sh/contributing/style-guide)
