### PR TITLE
Fix typo in HTML class attribute for input component

### DIFF
--- a/web/src/pages/components/input.mdx
+++ b/web/src/pages/components/input.mdx
@@ -69,7 +69,7 @@ Instead, wrap an `<input>` with a `<label box-="*">` or use a `contenteditable` 
         }
     `}
     html={`<label box-="round" shear-="top">
-    <div clas="row">
+    <div class="row">
         <span is-="badge" variant-="background0">Username</span>
     </div>
     <input placeholder="johndoe123" />


### PR DESCRIPTION
Small typo in example for https://webtui.ironclad.sh/components/input/

<img width="740" height="290" alt="Screenshot 2026-06-07 at 7 00 35 PM" src="https://github.com/user-attachments/assets/7dda5e7f-21cf-4a4e-a7b3-5f50c2b984da" />
