### PR TITLE
fix: add `initial-value` for `--progress-value`, `--progress-max`

### DIFF
--- a/packages/css/src/components/progress.css
+++ b/packages/css/src/components/progress.css
@@ -1,17 +1,17 @@
 @layer components {
     @property --progress-value {
         syntax: '<number>';
-        inherits: false;
+        inherits: true;
+        initial-value: 0;
     }
 
     @property --progress-max {
         syntax: '<number>';
-        inherits: false;
+        inherits: true;
+        initial-value: 100;
     }
 
     [is-~='progress'] {
-        --progress-value: 0;
-        --progress-max: 100;
         --progress-value-background: var(--foreground0);
         --progress-value-color: var(--foreground0);
         --progress-value-content: '';


### PR DESCRIPTION
Addresses #171

According to the [MDN
Documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@property/initial-value), `@property` at-rules are invalid and ignored if the `syntax` descriptor is not `*` and `initial-value` is unset, which is exactly what was happening here.

Fixes #issue-number

## What does this PR do?

## Checklist

- [ ] I have read the [Contributing Guide](https://webtui.ironclad.sh/contributing/contributing)
- [ ] My Pull Request abides by the [Style Guide](https://webtui.ironclad.sh/contributing/style-guide)
