### PR TITLE
chore: add `word-break: break-all` to `html, body`

### DIFF
--- a/packages/css/src/base.css
+++ b/packages/css/src/base.css
@@ -42,6 +42,7 @@
         font-weight: var(--font-weight-normal);
         line-height: var(--line-height, 1.5);
         font-variant-ligatures: common-ligatures;
+        word-break: break-all;
     }
 
     * {


### PR DESCRIPTION
Addresses #168

TUIs don't usually (USUALLY) wrap words gracefully, and this is the default behavior for most terminals.

A different `word-break` value can be applied manually.