### PR TITLE
chore: add more color variants and css variable control to components

### DIFF
--- a/packages/css/src/base.css
+++ b/packages/css/src/base.css
@@ -17,9 +17,6 @@
         --font-family: monospace;
 
         --box-border-color: var(--foreground0);
-        --table-border-color: var(--box-border-color);
-        --separator-color: var(--box-border-color);
-        --separator-background: transparent;
     }
 
     [data-webtui-theme='dark'] {

--- a/packages/css/src/components/separator.css
+++ b/packages/css/src/components/separator.css
@@ -6,7 +6,8 @@
     }
 
     [is-~='separator'] {
-        --separator-bg-fallback: var(--separator-background, transparent);
+        --separator-color: var(--box-border-color);
+        --separator-background: transparent;
 
         display: inline-flex;
         position: relative;
@@ -17,16 +18,16 @@
             height: 1lh;
             background-image: linear-gradient(
                 0deg,
-                var(--separator-bg-fallback) 0,
-                var(--separator-bg-fallback)
+                var(--separator-background) 0,
+                var(--separator-background)
                     calc(0.5lh - var(--separator-width) / 2),
                 var(--separator-color)
                     calc(0.5lh - (var(--separator-width) / 2)),
                 var(--separator-color)
                     calc(0.5lh + (var(--separator-width) / 2)),
-                var(--separator-bg-fallback)
+                var(--separator-background)
                     calc(0.5lh + (var(--separator-width) / 2)),
-                var(--separator-bg-fallback)
+                var(--separator-background)
             );
 
             &[cap-^='bisect']::before {
@@ -55,16 +56,16 @@
             width: 1ch;
             background-image: linear-gradient(
                 to right,
-                var(--separator-bg-fallback) 0,
-                var(--separator-bg-fallback)
+                var(--separator-background) 0,
+                var(--separator-background)
                     calc(0.5ch - (var(--separator-width) / 2)),
                 var(--separator-color)
                     calc(0.5ch - (var(--separator-width) / 2)),
                 var(--separator-color)
                     calc(0.5ch + (var(--separator-width) / 2)),
-                var(--separator-bg-fallback)
+                var(--separator-background)
                     calc(0.5ch + (var(--separator-width) / 2)),
-                var(--separator-bg-fallback)
+                var(--separator-background)
             );
 
             &[cap-^='bisect']::before {
@@ -97,6 +98,28 @@
                 height: 1lh;
                 background-image: inherit;
             }
+        }
+
+        &[variant-='foreground0'] {
+            --separator-color: var(--foreground0);
+        }
+        &[variant-='foreground1'] {
+            --separator-color: var(--foreground1);
+        }
+        &[variant-='foreground2'] {
+            --separator-color: var(--foreground2);
+        }
+        &[variant-='background0'] {
+            --separator-color: var(--background0);
+        }
+        &[variant-='background1'] {
+            --separator-color: var(--background1);
+        }
+        &[variant-='background2'] {
+            --separator-color: var(--background2);
+        }
+        &[variant-='background3'] {
+            --separator-color: var(--background3);
         }
     }
 }

--- a/packages/css/src/components/table.css
+++ b/packages/css/src/components/table.css
@@ -6,6 +6,8 @@
     }
 
     table {
+        --table-border-color: var(--box-border-color);
+
         border: none;
         outline: none;
         font-family: var(--font-family);
@@ -89,6 +91,28 @@
             &:first-of-type th {
                 padding-top: 0;
             }
+        }
+
+        &[variant-='foreground0'] {
+            --table-border-color: var(--foreground0);
+        }
+        &[variant-='foreground1'] {
+            --table-border-color: var(--foreground1);
+        }
+        &[variant-='foreground2'] {
+            --table-border-color: var(--foreground2);
+        }
+        &[variant-='background0'] {
+            --table-border-color: var(--background0);
+        }
+        &[variant-='background1'] {
+            --table-border-color: var(--background1);
+        }
+        &[variant-='background2'] {
+            --table-border-color: var(--background2);
+        }
+        &[variant-='background3'] {
+            --table-border-color: var(--background3);
         }
     }
 }

--- a/packages/css/src/components/typography.css
+++ b/packages/css/src/components/typography.css
@@ -29,7 +29,7 @@
         list-style-type: none;
 
         li::before {
-            color: inherit;
+            color: var(--list-marker-color, inherit);
             content: '- ';
         }
 
@@ -77,7 +77,10 @@
                 width: var(--box-border-width, 2px);
                 height: 100%;
                 translate: -50%;
-                background-color: var(--background2);
+                background-color: var(
+                    --blockquote-indent-color,
+                    var(--background2)
+                );
             }
         }
 

--- a/web/src/pages/components/separator.mdx
+++ b/web/src/pages/components/separator.mdx
@@ -40,11 +40,44 @@ A horizontal or vertical separator
 <!-- Vertical -->
 <div is-="separator" direction-="vertical"></div>
 <div is-="separator" direction-="y"></div>
+
+<!-- Color Variant -->
+<div is-="separator" variant-="background1"></div>
+<div is-="separator" variant-="foreground1"></div>
 ```
 
 If `direction-` is not specified, separators are horizontal by default.
 
 ## Examples
+
+### Variants
+
+<Example
+    stylesheets={[separatorStyle]}
+    css={`
+        body {
+            display: flex;
+            flex-direction: column;
+        }
+    `}
+    html={`<span>foreground0:</span>
+<div is-="separator" variant-="foreground0"></div>
+<span>foreground1:</span>
+<div is-="separator" variant-="foreground1"></div>
+<span>foreground2:</span>
+<div is-="separator" variant-="foreground2"></div>
+<span>background0:</span>
+<div is-="separator" variant-="background0"></div>
+<span>background1:</span>
+<div is-="separator" variant-="background1"></div>
+<span>background2:</span>
+<div is-="separator" variant-="background2"></div>
+<span>background3:</span>
+<div is-="separator" variant-="background3"></div>
+`}
+/>
+
+Available variants match the [base theme colors](/start/theming#colors)
 
 ### Vertical
 

--- a/web/src/pages/components/table.mdx
+++ b/web/src/pages/components/table.mdx
@@ -69,9 +69,36 @@ Displays a table
 </table>
 ```
 
+## Examples
+
+### Variants
+
+Use the `variant-` attribute to change the color of the table borders
+
+```html
+<table variant-="foreground1"></table>
+```
+
+<Example
+    stylesheets={[tableStyle]}
+    css={`
+        body {
+            display: flex;
+            flex-direction: column;
+        }
+    `}
+    html={`<table variant-="foreground0"><tr><th>variant-</th><td>foreground0</td></tr></table>
+<table variant-="foreground1"><tr><th>variant-</th><td>foreground1</td></tr></table>
+<table variant-="foreground2"><tr><th>variant-</th><td>foreground2</td></tr></table>
+<table variant-="background0"><tr><th>variant-</th><td>background0</td></tr></table>
+<table variant-="background1"><tr><th>variant-</th><td>background1</td></tr></table>
+<table variant-="background2"><tr><th>variant-</th><td>background2</td></tr></table>
+<table variant-="background3"><tr><th>variant-</th><td>background3</td></tr></table>`}
+/>
+
 ## Caveats
 
-The `<caption>` element absolutely obliterates the ascii box-like styling
+The `<caption>` element absolutely obliterates the ascii box-like styling, don't use it
 
 ## Reference
 

--- a/web/src/pages/components/typography.mdx
+++ b/web/src/pages/components/typography.mdx
@@ -70,6 +70,28 @@ Block Quotes
 `}
 />
 
+Use the `--blockquote-indent-color` CSS variable to change the color of the indentation
+
+```css
+blockquote {
+    --blockquote-indent-color: red;
+}
+```
+
+<Example
+    stylesheets={[typographyStylesheet]}
+    css={`
+        blockquote {
+            --blockquote-indent-color: red;
+        }
+    `}
+    html={`
+<blockquote>
+    Lorem Ipsum Dolor Sit Amet
+</blockquote>
+`}
+/>
+
 ### `<ol>`
 
 Ordered Lists
@@ -166,6 +188,31 @@ Use the `open` keyword at the start and/or end of the `marker-` attribute to lea
     <li><code>marker-="open tree open"</code></li>
 </ul>
 `}
+/>
+
+Use the `--list-marker-color` CSS variable to change the color of list markers
+
+```css
+li {
+    --list-marker-color: red;
+}
+```
+
+<Example
+    stylesheets={[
+        typographyStylesheet,
+        `body { display: flex; flex-direction: column; gap: 1lh; }`,
+    ]}
+    css={`
+        li {
+            --list-marker-color: red;
+        }
+    `}
+    html={`<ul>
+    <li>red</li>
+    <li>hot</li>
+    <li>list markers</li>
+</ul>`}
 />
 
 ### `[is-="typography-block"]`


### PR DESCRIPTION
- Addresses #167
- Addresses #166

Adds some more color control via CSS variables and the `variant-` prop to different components.

- Moves table and separator color variables to their respective files
- Adds a `variant-` attribute to the Separator component with all the base theme colors
- Adds a `variant-` attribute to the Table component with all the base theme colors
- Adds `--list-marker-color` to the typography stylesheet for `li` elements
- Adds `--blockquote-indent-color` to the typography stylesheet for `blockquote` elements