### PR TITLE
feat: table directions

### DIFF
--- a/packages/css/src/components/table.css
+++ b/packages/css/src/components/table.css
@@ -17,82 +17,89 @@
         text-align: left;
         position: relative;
         border-spacing: 0 0;
-        padding-top: 1lh;
-        padding-left: 1ch;
 
-        &::before {
-            content: '';
-            position: absolute;
-            top: calc(0.5lh - (var(--table-border-width) / 2));
-            left: calc(0.5ch - (var(--table-border-width) / 2));
-            width: calc(100% - 1ch);
-            height: calc(100% - 1lh);
-            border-top: solid var(--table-border-width)
-                var(--table-border-color);
-            border-left: solid var(--table-border-width)
-                var(--table-border-color);
+        th {
+            font-weight: var(--font-weight-bold);
         }
 
-        tr {
-            th {
-                font-weight: var(--font-weight-bold);
-            }
+        th,
+        td {
+            position: relative;
+            padding-right: 1ch;
 
-            & > *:is(th, td) {
+            &:last-of-type {
+                padding-right: 0;
+            }
+        }
+
+        &[divide-='vertical'],
+        &[divide-='both'],
+        &:not([divide-]) {
+            th,
+            td {
+                &:not(:last-of-type) {
+                    &::before {
+                        content: '';
+                        position: absolute;
+                        right: calc(0.5ch - var(--table-border-width) / 2);
+                        bottom: 0;
+                        border-left: solid var(--table-border-width)
+                            var(--table-border-color);
+                        height: 100%;
+                    }
+
+                    table[box-] &::before {
+                        bottom: calc(-0.5lh - var(--table-border-width) / 2);
+                        border-left: solid var(--table-border-width)
+                            var(--table-border-color);
+                        height: calc(100% + 1lh);
+                    }
+                }
+            }
+        }
+
+        &[divide-='horizontal'],
+        &[divide-='both'],
+        &:not([divide-]) {
+            tr {
                 position: relative;
-                padding-right: 1ch;
-                padding-bottom: 1lh;
 
-                &::before {
-                    content: '';
-                    position: absolute;
-                    right: calc(0.5ch - var(--table-border-width) / 2);
-                    bottom: calc(0.5lh - var(--table-border-width) / 2);
-                    border-left: solid var(--table-border-width)
-                        var(--table-border-color);
-                    height: 100%;
-                }
+                th,
+                td {
+                    padding-bottom: 1lh;
 
-                &::after {
-                    content: '';
-                    position: absolute;
-                    left: calc(-0.5ch);
-                    bottom: calc(0.5lh - var(--table-border-width) / 2);
-                    width: 100%;
-                    border-top: solid var(--table-border-width)
-                        var(--table-border-color);
+                    &::after {
+                        content: '';
+                        position: absolute;
+                        left: 0;
+                        bottom: calc(0.5lh - var(--table-border-width) / 2);
+                        width: 100%;
+                        border-top: solid var(--table-border-width)
+                            var(--table-border-color);
+                    }
+
+                    table[box-] &::after {
+                        left: calc(-0.5ch - var(--table-border-width) / 2);
+                        width: calc(100% + 1ch);
+                        border-top: solid var(--table-border-width)
+                            var(--table-border-color);
+                    }
                 }
             }
         }
 
-        thead + tbody tr,
-        tbody + tfoot tr {
-            &:first-of-type td,
-            &:first-of-type th {
-                padding-top: 0;
+        &[divide-='horizontal'],
+        &[divide-='both'],
+        &:not([divide-]) {
+            *:last-child tr:last-child {
+                th,
+                td {
+                    padding-bottom: 0;
+                    &::after {
+                        display: none;
+                    }
+                }
             }
-        }
-
-        &[variant-='foreground0'] {
-            --table-border-color: var(--foreground0);
-        }
-        &[variant-='foreground1'] {
-            --table-border-color: var(--foreground1);
-        }
-        &[variant-='foreground2'] {
-            --table-border-color: var(--foreground2);
-        }
-        &[variant-='background0'] {
-            --table-border-color: var(--background0);
-        }
-        &[variant-='background1'] {
-            --table-border-color: var(--background1);
-        }
-        &[variant-='background2'] {
-            --table-border-color: var(--background2);
-        }
-        &[variant-='background3'] {
-            --table-border-color: var(--background3);
         }
     }
 }

--- a/web/src/pages/components/table.mdx
+++ b/web/src/pages/components/table.mdx
@@ -5,6 +5,7 @@ title: Table
 
 import Example from '@/components/Example.astro'
 import tableStyle from '@webtui/css/components/table.css?raw'
+import boxStyle from '@webtui/css/utils/box.css?raw'
 
 Displays a table
 
@@ -55,7 +56,6 @@ Displays a table
         <tr>
             <td>...</td>
             <td>...</td>
-            <td>...</td>
         </tr>
     </thead>
     <tbody>
@@ -66,39 +66,145 @@ Displays a table
         </tr>
         ...
     </tbody>
+    <tfoot>
+        <tr>
+            <td>...</td>
+        </tr>
+    </tfoot>
 </table>
 ```
 
 ## Examples
 
-### Variants
+### Divide
 
-Use the `variant-` attribute to change the color of the table borders
+Use the `divide-` attribute to change the direction of the table dividers
 
 ```html
-<table variant-="foreground1"></table>
+<table variant-="horizontal"></table>
+<table variant-="vertical"></table>
+<table variant-="both"></table>
+<!-- Not providing `variant-` is the same as `variant-="both"` -->
+<table></table>
 ```
 
 <Example
-    stylesheets={[tableStyle]}
-    css={`
-        body {
-            display: flex;
-            flex-direction: column;
-        }
+    stylesheets={[tableStyle, `table {margin-bottom: 1lh;}`]}
+    html={`
+<table divide-="both">
+    <thead>
+        <tr>
+            <th>divide-</th>
+            <th>both</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>or</td>
+            <td>also</td>
+        </tr>
+        <tr>
+            <td>divide-</td>
+            <td>&lt;not provided&gt;</td>
+        </tr>
+    </tbody>
+</table>
+<table divide-="horizontal">
+    <thead>
+        <tr>
+            <th>divide-</th>
+            <th>horizontal</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>hey</td>
+            <td>look</td>
+        </tr>
+        <tr>
+            <td>horizontal</td>
+            <td>lines</td>
+        </tr>
+    </tbody>
+</table>
+<table divide-="vertical">
+    <thead>
+        <tr>
+            <th>divide-</th>
+            <th>vertical</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>hey</td>
+            <td>look</td>
+        </tr>
+        <tr>
+            <td>vertical</td>
+            <td>lines</td>
+        </tr>
+    </tbody>
+</table>
     `}
-    html={`<table variant-="foreground0"><tr><th>variant-</th><td>foreground0</td></tr></table>
-<table variant-="foreground1"><tr><th>variant-</th><td>foreground1</td></tr></table>
-<table variant-="foreground2"><tr><th>variant-</th><td>foreground2</td></tr></table>
-<table variant-="background0"><tr><th>variant-</th><td>background0</td></tr></table>
-<table variant-="background1"><tr><th>variant-</th><td>background1</td></tr></table>
-<table variant-="background2"><tr><th>variant-</th><td>background2</td></tr></table>
-<table variant-="background3"><tr><th>variant-</th><td>background3</td></tr></table>`}
 />
 
-## Caveats
+## ASCII Boxes
 
-The `<caption>` element absolutely obliterates the ascii box-like styling, don't use it
+Pair the table component with the [`box-` utility](/start/ascii-boxes) to add box borders around the table
+
+```html
+<table box-="square" divide-="both"></table>
+<table box-="round" divide-="horizontal"></table>
+<table box-="double" divide-="vertical"></table>
+```
+
+<Example
+    stylesheets={[tableStyle, `table {margin-bottom: 1lh;}`, boxStyle]}
+    html={`
+<table divide-="both" box-="square">
+    <thead>
+        <tr>
+            <th>divide-</th>
+            <th>both</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>box-</td>
+            <td>square</td>
+        </tr>
+    </tbody>
+</table>
+<table divide-="horizontal" box-="round">
+    <thead>
+        <tr>
+            <th>divide-</th>
+            <th>horizontal</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>box-</td>
+            <td>round</td>
+        </tr>
+    </tbody>
+</table>
+<table divide-="vertical" box-="double">
+    <thead>
+        <tr>
+            <th>divide-</th>
+            <th>vertical</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>box-</td>
+            <td>double</td>
+        </tr>
+    </tbody>
+</table>
+    `}
+/>
 
 ## Reference
 
@@ -106,6 +212,8 @@ The `<caption>` element absolutely obliterates the ascii box-like styling, don't
 
 - `--table-border-width`: The width of the table borders
 - `--table-border-color`: The color of the table borders
+
+**Note**: If used with `box-`, `--table-border-color` inherits the value of `--box-border-color`
 
 ```css
 table {
@@ -129,16 +237,10 @@ To extend the Table stylesheet, define a CSS rule on the `components` layer
 ### Scope
 
 - All `<table>` elements
-- All `<thead>`, `<tbody>`, `<tfoot>`, `<tr>`, `<th>`, and `<td>` elements that are children of a `<table>`
+- All `<tr>`, `<th>`, and `<td>` elements that are children of a `<table>`
 
 ```css
 table {
-    thead,
-    tbody,
-    tfoot {
-        /* ... */
-    }
-
     tr {
         th {
             /* ... */


### PR DESCRIPTION
Addresses #181

- Adds the `divide-` attribute to the Table component, allowing for `horizontal`, `vertical`, and `both` borders.
- Allows tables to use the `box-` utility instead of having its own borders.