### PR TITLE
Add table example with 'divide-"none"' attribute

### DIFF
--- a/web/src/pages/components/table.mdx
+++ b/web/src/pages/components/table.mdx
@@ -81,11 +81,11 @@ Displays a table
 Use the `divide-` attribute to change the direction of the table dividers
 
 ```html
-<table variant="none"></table>
-<table variant-="horizontal"></table>
-<table variant-="vertical"></table>
-<table variant-="both"></table>
-<!-- Not providing `variant-` is the same as `variant-="both"` -->
+<table divide-="none"></table>
+<table divide-="horizontal"></table>
+<table divide-="vertical"></table>
+<table divide-="both"></table>
+<!-- Not providing `divide-` is the same as `divide-="both"` -->
 <table></table>
 ```
 
@@ -172,6 +172,7 @@ Use the `divide-` attribute to change the direction of the table dividers
 Pair the table component with the [`box-` utility](/start/ascii-boxes) to add box borders around the table
 
 ```html
+<table box-="none" divide-="none"></table>
 <table box-="square" divide-="both"></table>
 <table box-="round" divide-="horizontal"></table>
 <table box-="double" divide-="vertical"></table>
@@ -219,6 +220,20 @@ Pair the table component with the [`box-` utility](/start/ascii-boxes) to add bo
         <tr>
             <td>box-</td>
             <td>double</td>
+        </tr>
+    </tbody>
+</table>
+<table divide-="none" box-="none">
+    <thead>
+        <tr>
+            <th>divide-</th>
+            <th>none</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>box-</td>
+            <td>none</td>
         </tr>
     </tbody>
 </table>

--- a/web/src/pages/components/table.mdx
+++ b/web/src/pages/components/table.mdx
@@ -81,6 +81,7 @@ Displays a table
 Use the `divide-` attribute to change the direction of the table dividers
 
 ```html
+<table variant="none"></table>
 <table variant-="horizontal"></table>
 <table variant-="vertical"></table>
 <table variant-="both"></table>
@@ -141,6 +142,24 @@ Use the `divide-` attribute to change the direction of the table dividers
         </tr>
         <tr>
             <td>vertical</td>
+            <td>lines</td>
+        </tr>
+    </tbody>
+</table>
+<table divide-="none">
+    <thead>
+        <tr>
+            <th>divide-</th>
+            <th>none</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>hey</td>
+            <td>look</td>
+        </tr>
+        <tr>
+            <td>no</td>
             <td>lines</td>
         </tr>
     </tbody>


### PR DESCRIPTION
Added a new table example with 'divide-"none"' attribute to demonstrate different divider options.

Fixes #191 

## What does this PR do?
I included in the table component an example of divide-"none" and its corresponding table element. 
## Checklist

- [x] I have read the [Contributing Guide](https://webtui.ironclad.sh/contributing/contributing)
- [x] My Pull Request abides by the [Style Guide](https://webtui.ironclad.sh/contributing/style-guide)
