### PR TITLE
feat: improve checkbox component

### DIFF
--- a/packages/css/src/components/checkbox.css
+++ b/packages/css/src/components/checkbox.css
@@ -1,5 +1,12 @@
 @layer components {
-    input[type='checkbox']:not([is-='switch']) {
+    input[type='checkbox'][is-='checkbox'] {
+        --placeholder-content: '[ ]';
+        --placeholder-background: var(--background1);
+        --placeholder-color: var(--foreground2);
+        --checked-content: '✓';
+        --checked-background: transparent;
+        --checked-color: var(--foreground0);
+
         appearance: none;
         -webkit-appearance: none;
         -moz-appearance: none;
@@ -8,48 +15,45 @@
         width: 3ch;
         min-width: initial;
         vertical-align: text-top;
-        color: var(--foreground2);
         font-family: var(--font-family);
         font-size: var(--font-size);
         line-height: var(--line-height);
         outline: none;
-    }
 
-    input[type='checkbox']:not([is-='switch'])::before {
-        content: '';
-        position: absolute;
-        inset: 0;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 3ch;
-        height: 1lh;
-        background: var(--background1);
-    }
+        &::before,
+        &::after {
+            position: absolute;
+            inset: 0;
+            text-align: center;
+            width: 3ch;
+            height: 1lh;
+        }
 
-    input[type='checkbox']:not([is-='switch']):checked::before {
-        content: 'X';
-    }
+        &::before {
+            content: var(--placeholder-content);
+            background-color: var(--placeholder-background);
+            color: var(--placeholder-color);
+        }
 
-    label:has(input[type='checkbox']:not([is-='switch'])) {
-        display: inline-flex;
-        align-items: flex-start;
-        gap: 1ch;
-        max-width: fit-content;
-    }
+        &:checked::after {
+            content: var(--checked-content);
+            background-color: var(--checked-background);
+            color: var(--checked-color);
+        }
 
-    label:has(input[type='checkbox']:not([is-='switch']):focus) {
-        font-weight: bold;
-        text-decoration: underline;
-    }
+        &:disabled {
+            &::before,
+            &::after {
+                color: var(--placeholder-color);
+                text-decoration: line-through;
+                text-decoration-color: var(--placeholder-foreground);
+            }
+        }
 
-    input[type='checkbox']:not([is-='switch']):disabled {
-        color: var(--foreground2);
-        pointer-events: none;
-    }
-
-    label:has(input[type='checkbox']:not([is-='switch']):disabled) {
-        color: var(--foreground2);
-        text-decoration: line-through;
+        &:focus,
+        &:focus::before,
+        &:focus::after {
+            text-decoration: underline;
+        }
     }
 }

--- a/web/src/pages/components/checkbox.mdx
+++ b/web/src/pages/components/checkbox.mdx
@@ -11,8 +11,12 @@ Displays a checkbox
 <Example
     stylesheets={[checkboxStyle]}
     html={`<label>
-    <input type="checkbox" />
-    Checkbox
+    <input type="checkbox" is-="checkbox" />
+    Unchecked
+</label>
+<label>
+    <input type="checkbox" is-="checkbox" checked />
+    Checked
 </label>`}
 />
 
@@ -24,42 +28,28 @@ Displays a checkbox
 
 ## Usage
 
+Both `type="checkbox"` and `is-="checkbox"` are necessary because the [switch](/components/switch) component is also a checkbox under the hood
+
 ```html
 <label>
-    <input type="checkbox" />
+    <input type="checkbox" is-="checkbox" />
     Checkbox
 </label>
 ```
 
 ## Examples
 
-### Checked/Unchecked
+### `disabled`
 
 <Example
     stylesheets={[checkboxStyle]}
     html={`
 <label>
-    <input type="checkbox" />
-    Unchecked
-</label>
-<label>
-    <input type="checkbox" checked />
-    Checked
-</label>
-`}
-/>
-
-### Disabled
-
-<Example
-    stylesheets={[checkboxStyle]}
-    html={`
-<label>
-    <input type="checkbox" disabled />
+    <input type="checkbox" is-="checkbox" disabled />
     Disabled
 </label>
 <label>
-    <input type="checkbox" checked disabled />
+    <input type="checkbox" is-="checkbox" checked disabled />
     Checked Disabled
 </label>
 `}
@@ -67,13 +57,51 @@ Displays a checkbox
 
 ## Reference
 
+### Properties
+
+- `--placeholder-content`: The content of the checkbox placeholder
+- `--placeholder-background`: The background color of the checkbox placeholder
+- `--placeholder-color`: The text color of the checkbox placeholder
+- `--checked-content`: The content of the checkbox when checked
+- `--checked-background`: The background color of the checkbox when checked
+- `--checked-color`: The text color of the checkbox when checked
+
+<Example
+    stylesheets={[checkboxStyle]}
+    css={`input[type="checkbox"][is-="checkbox"].custom {
+    --placeholder-content: '( )';
+    --placeholder-background: var(--background2);
+    --placeholder-color: var(--foreground1);
+    --checked-content: 'X';
+    --checked-color: red;
+}`}
+    html={`
+<label>
+    <input type="checkbox" is-="checkbox" />
+    Default
+</label>
+<label>
+    <input type="checkbox" is-="checkbox" checked />
+    Default Checked
+</label><br/>
+<label>
+    <input type="checkbox" is-="checkbox" class="custom" />
+    Custom
+</label>
+<label>
+    <input type="checkbox" is-="checkbox" checked class="custom" />
+    Custom Checked
+</label>
+`}
+/>
+
 ### Extending
 
 To extend the Checkbox stylesheet, define a CSS rule on the `components` layer
 
 ```css
 @layer components {
-    input[type='checkbox']:not([is-='switch']) {
+    input[type='checkbox'][is-='checkbox'] {
         /* ... */
     }
 }
@@ -81,10 +109,10 @@ To extend the Checkbox stylesheet, define a CSS rule on the `components` layer
 
 ### Scope
 
-- All native `<input type="checkbox">` elements without `is-="switch"`
+- All native `<input type="checkbox">` elements with `is-="checkbox"`
 
 ```css
-input[type='checkbox']:not([is-='switch']) {
+input[type='checkbox'][is-='checkbox'] {
     /* ... */
 }
 ```

--- a/web/src/pages/start/changelog.mdx
+++ b/web/src/pages/start/changelog.mdx
@@ -9,7 +9,12 @@ import preStyle from '@webtui/css/components/pre.css?raw'
 
 ## 0.1.10
 
+- Allows for more control over the [Checkbox Component](/components/checkbox) with CSS variables
+- Requires `is-="checkbox"` for the [Checkbox Component](/components/checkbox)
+
 ### Migration Guide from 0.1.9
+
+All checkboxes now require you to add `is-="checkbox"` otherwise they will be unstyled
 
 ## 0.1.9
 


### PR DESCRIPTION
Partially addresses #195 (checkboxes)

- Allows for better styling control of the checkbox component with CSS variables
- Requires you to add `is-="checkbox"`, removes the `:not([is-="switch"])` check
