### PR TITLE
feat: improve radio component

### DIFF
--- a/packages/css/src/components/radio.css
+++ b/packages/css/src/components/radio.css
@@ -1,5 +1,12 @@
 @layer components {
     input[type='radio'] {
+        --placeholder-content: '( )';
+        --placeholder-background: var(--background1);
+        --placeholder-color: var(--foreground2);
+        --checked-content: '*';
+        --checked-background: transparent;
+        --checked-color: var(--foreground0);
+
         appearance: none;
         -webkit-appearance: none;
         -moz-appearance: none;
@@ -8,48 +15,45 @@
         width: 3ch;
         min-width: initial;
         vertical-align: text-top;
-        color: var(--foreground2);
         font-family: var(--font-family);
         font-size: var(--font-size);
         line-height: var(--line-height);
         outline: none;
 
-        &::before {
-            content: '( )';
+        &::before,
+        &::after {
             position: absolute;
             inset: 0;
-            display: flex;
-            align-items: center;
-            justify-content: center;
+            text-align: center;
             width: 3ch;
             height: 1lh;
-            background: var(--background1);
         }
 
-        &:checked::before {
-            content: '(*)';
+        &::before {
+            content: var(--placeholder-content);
+            background-color: var(--placeholder-background);
+            color: var(--placeholder-color);
+        }
+
+        &:checked::after {
+            content: var(--checked-content);
+            background-color: var(--checked-background);
+            color: var(--checked-color);
         }
 
         &:disabled {
-            color: var(--foreground2);
-            pointer-events: none;
+            &::before,
+            &::after {
+                color: var(--placeholder-color);
+                text-decoration: line-through;
+                text-decoration-color: var(--placeholder-foreground);
+            }
         }
-    }
 
-    label:has(input[type='radio']) {
-        display: inline-flex;
-        align-items: flex-start;
-        gap: 1ch;
-        max-width: fit-content;
-    }
-
-    label:has(input[type='radio']:focus) {
-        font-weight: bold;
-        text-decoration: underline;
-    }
-
-    label:has(input[type='radio']:disabled) {
-        color: var(--foreground2);
-        text-decoration: line-through;
+        &:focus,
+        &:focus::before,
+        &:focus::after {
+            text-decoration: underline;
+        }
     }
 }

--- a/web/src/pages/components/checkbox.mdx
+++ b/web/src/pages/components/checkbox.mdx
@@ -68,13 +68,15 @@ Both `type="checkbox"` and `is-="checkbox"` are necessary because the [switch](/
 
 <Example
     stylesheets={[checkboxStyle]}
-    css={`input[type="checkbox"][is-="checkbox"].custom {
-    --placeholder-content: '( )';
-    --placeholder-background: var(--background2);
-    --placeholder-color: var(--foreground1);
-    --checked-content: 'X';
-    --checked-color: red;
-}`}
+    css={`
+        input[type='checkbox'][is-='checkbox'].custom {
+            --placeholder-content: '( )';
+            --placeholder-background: var(--background2);
+            --placeholder-color: var(--foreground1);
+            --checked-content: 'X';
+            --checked-color: red;
+        }
+    `}
     html={`
 <label>
     <input type="checkbox" is-="checkbox" />

--- a/web/src/pages/components/radio.mdx
+++ b/web/src/pages/components/radio.mdx
@@ -6,16 +6,18 @@ title: Radio
 import Example from '@/components/Example.astro'
 import radioStyle from '@webtui/css/components/radio.css?raw'
 
-Displays a radio input styled like a terminal UI radio
+Displays a radio button
 
 <Example
     stylesheets={[radioStyle]}
-    html={`
-<label>
-    <input type="radio" name="choice" />
-    Option
+    html={`<label>
+    <input type="radio" name="radio-group" />
+    Unchecked
 </label>
-`}
+<label>
+    <input type="radio" checked name="radio-group" />
+    Checked
+</label>`}
 />
 
 ## Import
@@ -28,40 +30,24 @@ Displays a radio input styled like a terminal UI radio
 
 ```html
 <label>
-    <input type="radio" name="choice" />
-    Option
+    <input type="radio" />
+    Radio
 </label>
 ```
 
 ## Examples
 
-### Checked/Unchecked
+### `disabled`
 
 <Example
     stylesheets={[radioStyle]}
     html={`
 <label>
-    <input type="radio" name="r" /> 
-    Unchecked 
-</label>
-<label>
-    <input type="radio" name="r" checked /> 
-    Checked 
-</label>
-`}
-/>
-
-### Disabled
-
-<Example
-    stylesheets={[radioStyle]}
-    html={`
-<label>
-    <input type="radio" name="r2" disabled />
+    <input type="radio" disabled name="radio-group" />
     Disabled
 </label>
 <label>
-    <input type="radio" name="r2" checked disabled /> 
+    <input type="radio" checked disabled name="radio-group" />
     Checked Disabled
 </label>
 `}
@@ -69,9 +55,49 @@ Displays a radio input styled like a terminal UI radio
 
 ## Reference
 
+### Properties
+
+- `--placeholder-content`: The content of the unchecked radio placeholder
+- `--placeholder-background`: The background color of the unchecked radio placeholder
+- `--placeholder-color`: The text color of the unchecked radio placeholder
+- `--checked-content`: The content of the radio button when checked
+- `--checked-background`: The background color of the radio button when checked
+- `--checked-color`: The text color of the radio button when checked
+
+<Example
+    stylesheets={[radioStyle]}
+    css={`
+        input[type='radio'].custom {
+            --placeholder-content: '< >';
+            --placeholder-background: var(--background2);
+            --placeholder-color: var(--foreground1);
+            --checked-content: 'O';
+            --checked-color: red;
+        }
+    `}
+    html={`
+<label>
+    <input type="radio" name="default" />
+    Default
+</label>
+<label>
+    <input type="radio" checked name="default" />
+    Default Checked
+</label><br/>
+<label>
+    <input type="radio" class="custom" name="custom" />
+    Custom
+</label>
+<label>
+    <input type="radio" checked class="custom" name="custom" />
+    Custom Checked
+</label>
+`}
+/>
+
 ### Extending
 
-To extend the Radio stylesheet, define a CSS rule on the `components` layer:
+To extend the Radio stylesheet, define a CSS rule on the `components` layer
 
 ```css
 @layer components {

--- a/web/src/pages/start/changelog.mdx
+++ b/web/src/pages/start/changelog.mdx
@@ -11,6 +11,7 @@ import preStyle from '@webtui/css/components/pre.css?raw'
 
 - Allows for more control over the [Checkbox Component](/components/checkbox) with CSS variables
 - Requires `is-="checkbox"` for the [Checkbox Component](/components/checkbox)
+- Allows for more control over the [Radio Component](/components/radio) with CSS variables
 
 ### Migration Guide from 0.1.9
 


### PR DESCRIPTION
Offers better control over the radio component with CSS variables, very similar to the checkbox component.

Formats checkbox.mdx because prettier is being annoying and indenting stuff

Partially addresses https://github.com/webtui/webtui/issues/195