### PR TITLE
chore: move position- attribute from popover to content

### DIFF
--- a/packages/css/src/components/popover.css
+++ b/packages/css/src/components/popover.css
@@ -50,41 +50,41 @@
                 z-index: 2;
             }
 
-            &[position-~='baseline-left'] summary + *,
-            &:not([position-]) summary + * {
+            & summary + *[position-~='baseline-left'],
+            & summary + *:not([position-]) {
                 left: 0%;
             }
 
-            &[position-~='baseline-right'] summary + * {
+            & summary + *[position-~='baseline-right'] {
                 left: 100%;
                 translate: -100%;
             }
 
-            &[position-~='left'] summary + * {
+            & summary + *[position-~='left'] {
                 left: calc(var(--popover-offset-x) * -1);
                 translate: -100%;
             }
 
-            &[position-~='right'] summary + * {
+            & summary + *[position-~='right'] {
                 left: calc(100% + var(--popover-offset-x));
             }
 
-            &[position-~='baseline-top'] summary + * {
+            & summary + *[position-~='baseline-top'] {
                 top: 0%;
             }
 
-            &[position-~='baseline-bottom'] summary + * {
+            & summary + *[position-~='baseline-bottom'] {
                 top: 100%;
                 transform: translateY(-100%);
             }
 
-            &[position-~='top'] summary + * {
+            & summary + *[position-~='top'] {
                 top: calc(var(--popover-offset-y) * -1);
                 transform: translateY(-100%);
             }
 
-            &[position-~='bottom'] summary + *,
-            &:not([position-]) summary + * {
+            & summary + *[position-~='bottom'],
+            & summary + *:not([position-]) {
                 top: calc(100% + var(--popover-offset-y));
             }
         }

--- a/web/src/pages/components/popover.mdx
+++ b/web/src/pages/components/popover.mdx
@@ -45,14 +45,12 @@ Creates a popover component powered by the [Details](https://developer.mozilla.o
 
 Use the `position-` property to control the position of the popover
 
-Pass two values into `position-` to set the horizontal and vertical position anchor
-
 ```html
-<details is-="popover" position-="<anchor>"></details>
-<details is-="popover" position-="<x-anchor> <y-anchor>"></details>
-
-<details is-="popover" position-="center"></details>
-<details is-="popover" position-="start end"></details>
+<details is-="popover"
+    >">
+    <summary>Popover</summary>
+    <div position-="bottom baseline-left">Popover content</div>
+</details>
 ```
 
 <Example
@@ -82,22 +80,22 @@ Pass two values into `position-` to set the horizontal and vertical position anc
     `}
     html={`
 <div class="row">
-    <details is-="popover" position-="bottom right">
+    <details is-="popover">
         <summary>BR ↘</summary>
-        <div class="popover-content">Popover content</div>
+        <div class="popover-content" position-="bottom right">Popover content</div>
     </details>
-    <details is-="popover" position-="bottom left">
+    <details is-="popover">
         <summary>BL ↙</summary>
-        <div class="popover-content">Popover content</div>
+        <div class="popover-content" position-="bottom left">Popover content</div>
     </details>
 </div>
 <div class="row">
-    <details is-="popover" position-="top right">
-        <summary>TR ↗</summary>
+    <details is-="popover">
+        <summary position-="top right">TR ↗</summary>
         <div class="popover-content">Popover content</div>
     </details>
-    <details is-="popover" position-="top left">
-        <summary>TL ↖</summary>
+    <details is-="popover">
+        <summary position-="top left">TL ↖</summary>
         <div class="popover-content">Popover content</div>
     </details>
 </div>
@@ -129,23 +127,23 @@ Use `baseline-*` values to position the content relative to the edges of the pop
     `}
     html={`
 <div class="row">
-    <details is-="popover" position-="bottom baseline-right">
+    <details is-="popover">
         <summary>Bottom Baseline-Right</summary>
-        <div class="popover-content">Popover content</div>
+        <div class="popover-content" position-="bottom baseline-right">Popover content</div>
     </details>
-    <details is-="popover" position-="bottom baseline-left">
+    <details is-="popover">
         <summary>Bottom Baseline-Left</summary>
-        <div class="popover-content">Popover content</div>
+        <div class="popover-content" position-="bottom baseline-left">Popover content</div>
     </details>
 </div>
 <div class="row">
-    <details is-="popover" position-="right baseline-top">
+    <details is-="popover">
         <summary>Right Baseline-Top</summary>
-        <div class="popover-content">Popover content</div>
+        <div class="popover-content" position-="right baseline-top">Popover content</div>
     </details>
-    <details is-="popover" position-="left baseline-bottom">
+    <details is-="popover">
         <summary>Left Baseline-Bottom</summary>
-        <div class="popover-content">Popover content</div>
+        <div class="popover-content" position-="left baseline-bottom">Popover content</div>
     </details>
 </div>
 `}

--- a/web/src/pages/start/changelog.mdx
+++ b/web/src/pages/start/changelog.mdx
@@ -12,10 +12,31 @@ import preStyle from '@webtui/css/components/pre.css?raw'
 - Allows for more control over the [Checkbox Component](/components/checkbox) with CSS variables
 - Requires `is-="checkbox"` for the [Checkbox Component](/components/checkbox)
 - Allows for more control over the [Radio Component](/components/radio) with CSS variables
+- The `position-` property for the [Popover Component](/components/popover) is now applied on the popover content element
 
 ### Migration Guide from 0.1.9
 
+#### Checkbox Styling
+
 All checkboxes now require you to add `is-="checkbox"` otherwise they will be unstyled
+
+#### Popover Positioning
+
+Instead of applying the `position-` property to the `<details>` element, you will need to apply it on the content element
+
+```html
+<!-- Old (<0.1.10) -->
+<details is-="popover" position-="bottom right">
+    <summary>Bottom Right</summary>
+    <div>Popover content</div>
+</details>
+
+<!-- New (>=0.1.10) -->
+<details is-="popover">
+    <summary>Bottom Right</summary>
+    <div position-="bottom right">Popover content</div>
+</details>
+```
 
 ## 0.1.9
 


### PR DESCRIPTION
Addresses #196

Moves the `position-` attribute from the `<details>` element to the
content element